### PR TITLE
Api/load accounts

### DIFF
--- a/staking-ts/tests/test.ts
+++ b/staking-ts/tests/test.ts
@@ -6,7 +6,7 @@ import {
   SystemProgram,
 } from "@solana/web3.js";
 import { Wallet, Provider } from "@project-serum/anchor";
-import fs from "fs";
+import assert from 'assert';
 import { StakeConnection } from "../src";
 
 // let's try to get rid of this magic constant
@@ -180,4 +180,17 @@ describe("api", async () => {
       alice,
     ]);
   });
+
+
+
+  it("find and parse stake accounts", async () => {
+    const res = await stake_connection.getStakeAccounts(alice.publicKey);
+
+    assert.equal(res[0].stake_account_positions.owner.toBase58(), alice.publicKey.toBase58());
+    assert.equal(res[0].stake_account_metadata.owner.toBase58(), alice.publicKey.toBase58());
+    assert.equal(res[0].stake_account_positions.positions[0], null);
+    assert.equal(res[0].token_balance, 1000)
+    
+  });
+
 });


### PR DESCRIPTION
High-level, these are method for the frontend to be able to get all the information about a user's stake accounts.
First, we need to find the addresses of the staking accounts through `getStakeAccounts` where we do a `getProgramAccounts` filtering for the type `PositionData` and an owner field corresponding to the current connected wallet.
Secondly, we can parse the accounts and create a `StakeAccount ` object with `loadStakeAccount`. This method makes use of the position wasm deserializer which is wrapped here in the private method `fetchPositionAccount `

StakeAccount contains all the current data necessary for the frontend to know what is the current withdrawable balance, locked and unvested.