### PR TITLE
Move constants to wasm to share them

### DIFF
--- a/staking/programs/staking/Cargo.toml
+++ b/staking/programs/staking/Cargo.toml
@@ -21,4 +21,4 @@ default = []
 anchor-lang = "0.22.0"
 anchor-spl = "0.22.0"
 wasm-bindgen = "0.2.79"
-
+js-sys = "0.3.56"

--- a/staking/programs/staking/src/wasm.rs
+++ b/staking/programs/staking/src/wasm.rs
@@ -1,10 +1,11 @@
 use crate::borsh::BorshSerialize;
 use crate::state::positions::PositionData;
 use anchor_lang::{prelude::Error, AccountDeserialize, Discriminator};
+use js_sys;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-/// Parses a PositionData account from buffer in the zero-copy "serialized" format 
+/// Parses a PositionData account from buffer in the zero-copy "serialized" format
 /// (which is not really serialized) and serialize it properly using Borsh. Anchor
 /// knows how to deserialize the Borsh version.
 pub fn convert_positions_account(buffer: &[u8], borsh: &mut [u8]) -> i16 {
@@ -25,6 +26,44 @@ fn convert_positions_account_impl(buffer: &[u8], borsh: &mut [u8]) -> Result<(),
     borsh[0..8].copy_from_slice(&PositionData::discriminator());
     borsh[8..(len + 8)].copy_from_slice(&serialized[..]);
     Ok(())
+}
+
+#[wasm_bindgen]
+pub struct Constants {}
+// Define a macro to re-export these constants to prevent copy-paste errors (already almost made one)
+macro_rules! reexport_seed_const {
+    ( $c:ident ) => {
+        #[wasm_bindgen]
+        impl Constants {
+            #[wasm_bindgen]
+            pub fn $c() -> js_sys::JsString {
+                crate::context::$c.into()
+            }
+        }
+    };
+}
+
+reexport_seed_const!(AUTHORITY_SEED);
+reexport_seed_const!(CUSTODY_SEED);
+reexport_seed_const!(STAKE_ACCOUNT_METADATA_SEED);
+reexport_seed_const!(CONFIG_SEED);
+reexport_seed_const!(VOTER_RECORD_SEED);
+
+#[wasm_bindgen]
+impl Constants {
+    #[wasm_bindgen]
+    pub fn ANCHOR_DISCRIMINATOR_SIZE() -> usize {
+        //anchor_lang::Discriminator::discriminator().len()
+        8
+    }
+    #[wasm_bindgen]
+    pub fn MAX_POSITIONS() -> usize {
+        crate::state::positions::MAX_POSITIONS
+    }
+    #[wasm_bindgen]
+    pub fn POSITIONS_ACCOUNT_SIZE() -> usize {
+        Constants::ANCHOR_DISCRIMINATOR_SIZE() + std::mem::size_of::<PositionData>()
+    }
 }
 
 #[wasm_bindgen]

--- a/staking/tests/staking.ts
+++ b/staking/tests/staking.ts
@@ -33,14 +33,6 @@ describe("staking", async () => {
 
 
 
-  const CONFIG_SEED = "config";
-  const STAKE_ACCOUNT_METADATA_SEED = "stake_metadata";
-  const CUSTODY_SEED = "custody";
-  const AUTHORITY_SEED = "authority";
-  const VOTER_SEED = "voter_weight";
-
-
-
   const provider = anchor.Provider.local();
 
   const stake_account_positions_secret = new Keypair();
@@ -60,13 +52,13 @@ describe("staking", async () => {
     program = anchor.workspace.Staking as Program<Staking>;
 
     [config_account, bump] = await PublicKey.findProgramAddress(
-      [anchor.utils.bytes.utf8.encode(CONFIG_SEED)],
+      [anchor.utils.bytes.utf8.encode(wasm.Constants.CONFIG_SEED())],
       program.programId
     );
     let voterBump = 0;
     [voterAccount, voterBump] = await PublicKey.findProgramAddress(
       [
-        anchor.utils.bytes.utf8.encode(VOTER_SEED),
+        anchor.utils.bytes.utf8.encode(wasm.Constants.VOTER_RECORD_SEED()),
         stake_account_positions_secret.publicKey.toBuffer(),
       ],
       program.programId
@@ -131,7 +123,7 @@ describe("staking", async () => {
 
     const [metadataAccount, metadataBump] = await PublicKey.findProgramAddress(
       [
-        anchor.utils.bytes.utf8.encode(STAKE_ACCOUNT_METADATA_SEED),
+        anchor.utils.bytes.utf8.encode(wasm.Constants.STAKE_ACCOUNT_METADATA_SEED()),
         stake_account_positions_secret.publicKey.toBuffer(),
       ],
       program.programId
@@ -139,7 +131,7 @@ describe("staking", async () => {
 
     const [custodyAccount, custodyBump] = await PublicKey.findProgramAddress(
       [
-        anchor.utils.bytes.utf8.encode(CUSTODY_SEED),
+        anchor.utils.bytes.utf8.encode(wasm.Constants.CUSTODY_SEED()),
         stake_account_positions_secret.publicKey.toBuffer(),
       ],
       program.programId
@@ -148,7 +140,7 @@ describe("staking", async () => {
     const [authorityAccount, authorityBump] =
       await PublicKey.findProgramAddress(
         [
-          anchor.utils.bytes.utf8.encode(AUTHORITY_SEED),
+          anchor.utils.bytes.utf8.encode(wasm.Constants.AUTHORITY_SEED()),
           stake_account_positions_secret.publicKey.toBuffer(),
         ],
         program.programId
@@ -156,7 +148,7 @@ describe("staking", async () => {
 
     const [voterAccount, voterBump] = await PublicKey.findProgramAddress(
       [
-        anchor.utils.bytes.utf8.encode(VOTER_SEED),
+        anchor.utils.bytes.utf8.encode(wasm.Constants.VOTER_RECORD_SEED()),
         stake_account_positions_secret.publicKey.toBuffer(),
       ],
       program.programId

--- a/staking/tests/utils/constant.ts
+++ b/staking/tests/utils/constant.ts
@@ -1,7 +1,4 @@
-const DISCRIMINANT_SIZE = 8;
-const POSITION_SIZE = 104;
-const MAX_POSITIONS = 100;
-const PUBKEY = 32;
+import { Constants } from "../../wasm/node/staking"; 
 
-export const positions_account_size =
-  POSITION_SIZE * MAX_POSITIONS + DISCRIMINANT_SIZE + PUBKEY;
+export const positions_account_size = Constants.POSITIONS_ACCOUNT_SIZE();
+


### PR DESCRIPTION
This lets us get rid of a bunch of duplicated strings by just pulling them from the rust code through wasm.
The size of the positions account is also auto-computed.