### PR TITLE
enforce anchor 0.22

### DIFF
--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -28,7 +28,7 @@ jobs:
         echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
     - name: Install Anchor
       working-directory: ./staking
-      run: npm i -g @project-serum/anchor-cli
+      run: npm i -g @project-serum/anchor-cli@0.22.0
     - name: Anchor test
       working-directory: ./staking
       run: yarn test

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -31,7 +31,7 @@ jobs:
         echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
     - name: Install Anchor
       working-directory: ./staking
-      run: npm i -g @project-serum/anchor-cli
+      run: npm i -g @project-serum/anchor-cli@0.22.0
     - name: Compile wasms
       working-directory: ./staking
       run: yarn build_wasm


### PR DESCRIPTION
Anchor 0.23.0 came out an was breaking our CI. We enforce in the github action that Anchor 0.22.0 is installed