### PR TITLE
Only allow voting position

### DIFF
--- a/staking/programs/staking/src/lib.rs
+++ b/staking/programs/staking/src/lib.rs
@@ -96,17 +96,23 @@ pub mod staking {
         if product.is_none() != publisher.is_none() {
             return Err(error!(ErrorCode::InvalidPosition));
         }
+        let new_position = Position {
+            amount: amount,
+            product: product,
+            publisher: publisher,
+            activation_epoch: current_epoch + 1,
+            unlocking_start: None,
+        };
+        // For now, restrict positions to voting position
+        // This could be combined with the previous check, but the following check is temporary
+        if !new_position.is_voting() {
+            return Err(error!(ErrorCode::NotImplemented));
+        }
 
         match PositionData::get_unused_index(stake_account_positions) {
             Err(x) => return Err(x),
             Ok(i) => {
-                stake_account_positions.positions[i] = Some(Position {
-                    amount: amount,
-                    product: product,
-                    publisher: publisher,
-                    activation_epoch: current_epoch + 1,
-                    unlocking_start: None,
-                });
+                stake_account_positions.positions[i] = Some(new_position);
             }
         }
 

--- a/staking/tests/staking.ts
+++ b/staking/tests/staking.ts
@@ -282,7 +282,7 @@ describe("staking", async () => {
   it("creates a position that's too big", async () => {
     expectFail(
       program.methods
-        .createPosition(zero_pubkey, zero_pubkey, new BN(102))
+        .createPosition(null, null, new BN(102))
         .accounts({
           stakeAccountPositions: stake_account_positions_secret.publicKey,
         }),
@@ -347,7 +347,7 @@ describe("staking", async () => {
   it("creates position with 0 principal", async () => {
     expectFail(
       program.methods
-        .createPosition(zero_pubkey, zero_pubkey, new BN(0))
+        .createPosition(null, null, new BN(0))
         .accounts({
           stakeAccountPositions: stake_account_positions_secret.publicKey,
         }),
@@ -356,9 +356,21 @@ describe("staking", async () => {
     );
   });
 
+  it("creates a non-voting position", async () => {
+    expectFail(
+      program.methods
+        .createPosition(zero_pubkey, zero_pubkey, new BN(10))
+        .accounts({
+          stakeAccountPositions: stake_account_positions_secret.publicKey,
+        }),
+      "Not implemented",
+      errMap
+    );
+  });
+
   it("creates too many positions", async () => {
     let createPosIx = await program.methods
-      .createPosition(zero_pubkey, zero_pubkey, new BN(1))
+      .createPosition(null, null, new BN(1))
       .accounts({
         stakeAccountPositions: stake_account_positions_secret.publicKey,
       })
@@ -394,7 +406,7 @@ describe("staking", async () => {
     // Now create 101, which is supposed to fail
     expectFail(
       program.methods
-        .createPosition(zero_pubkey, zero_pubkey, new BN(1))
+        .createPosition(null, null, new BN(1))
         .accounts({
           stakeAccountPositions: stake_account_positions_secret.publicKey,
         }),


### PR DESCRIPTION
We think that for the devnet launch it makes sense to only allow the voting position. Obviously the UI can only create the voting position right now, but this prevents anyone from sending the transaction directly.