### PR TITLE
make tab desc fixed height and fix mobile menu position

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -74,7 +74,7 @@ const Header = () => {
       <Dialog open={isMenuOpen} onClose={() => setIsMenuOpen(false)}>
         <div className="flex min-h-screen justify-center">
           <Dialog.Overlay className="fixed inset-0 bg-black" />
-          <div className="height-screen fixed top-0 mx-auto w-full rounded py-6 px-4">
+          <div className="height-screen fixed top-0 mx-auto w-full rounded py-6 px-8">
             <div className="flex items-center justify-end space-x-2">
               <button
                 className="rounded-full p-2 hover:bg-hoverGray"

--- a/frontend/pages/staking.tsx
+++ b/frontend/pages/staking.tsx
@@ -241,7 +241,7 @@ const Staking: NextPage = () => {
                   .map((v, idx) => (
                     <Tab.Panel key={idx}>
                       <div className="col-span-12 font-inter text-xs">
-                        <div className="mb-4 text-white sm:mb-12">
+                        <div className="mb-4 h-16 text-white sm:mb-12 sm:h-12">
                           {tabDescriptions[v as keyof typeof TabEnum]}
                         </div>
                         <div className="mb-2 flex">


### PR DESCRIPTION
- make tab descriptions fixed height so that card doesn't change size each time different tab is clicked
- make close menu icon same position as expand menu icon in mobile size
![image](https://user-images.githubusercontent.com/26521733/160375195-87398f58-ce2e-4834-ad00-fcf487be1a2c.png)
![image](https://user-images.githubusercontent.com/26521733/160375233-e0af97ab-da26-4710-9cab-407cd42d7222.png)
