### PR TITLE
Switch token transfer to use u64

### DIFF
--- a/staking/app/StakeConnection.ts
+++ b/staking/app/StakeConnection.ts
@@ -357,7 +357,7 @@ export class StakeConnection {
 
   private async buildTransferInstruction(
     stakeAccountPositionsAddress: PublicKey,
-    amount: number
+    amount: BN
   ): Promise<TransactionInstruction> {
     const from_account = await Token.getAssociatedTokenAddress(
       ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -382,7 +382,7 @@ export class StakeConnection {
       toAccount,
       this.program.provider.wallet.publicKey,
       [],
-      amount
+      new u64(amount.toString())
     );
 
     return ix;
@@ -390,7 +390,7 @@ export class StakeConnection {
 
   public async depositTokens(
     stakeAccount: StakeAccount | undefined,
-    amount: number
+    amount: BN
   ) {
     let stakeAccountAddress: PublicKey;
     const owner = this.program.provider.wallet.publicKey;
@@ -422,7 +422,7 @@ export class StakeConnection {
 
   public async depositAndLockTokens(
     stakeAccount: StakeAccount | undefined,
-    amount: number
+    amount: BN
   ) {
     let stakeAccountAddress: PublicKey;
     const owner = this.program.provider.wallet.publicKey;
@@ -448,7 +448,7 @@ export class StakeConnection {
     ixs.push(await this.buildTransferInstruction(stakeAccountAddress, amount));
 
     await this.program.methods
-      .createPosition(null, null, new BN(amount))
+      .createPosition(null, null, amount)
       .preInstructions(ixs)
       .accounts({
         stakeAccountPositions: stakeAccountAddress,

--- a/staking/tests/api_test.ts
+++ b/staking/tests/api_test.ts
@@ -68,7 +68,7 @@ describe("api", async () => {
       alice.publicKey,
       pythMintAccount.publicKey,
       pythMintAuthority,
-      1000,
+      new BN(1000),
       setupProgram.provider.connection
     );
   });
@@ -84,7 +84,7 @@ describe("api", async () => {
   });
 
   it("alice create deposit and lock", async () => {
-    await stakeConnection.depositAndLockTokens(undefined, 600);
+    await stakeConnection.depositAndLockTokens(undefined, new BN(600));
   });
 
   it("find and parse stake accounts", async () => {
@@ -111,7 +111,7 @@ describe("api", async () => {
       await stakeConnection.getTime()
     );
 
-    await stakeConnection.depositAndLockTokens(res[0], 100);
+    await stakeConnection.depositAndLockTokens(res[0], new BN(100));
 
     const after = await stakeConnection.getStakeAccounts(alice.publicKey);
     assert.equal(after.length, 1);

--- a/staking/tests/max_pos.ts
+++ b/staking/tests/max_pos.ts
@@ -62,7 +62,7 @@ describe("fills a stake account with positions", async () => {
     errMap = parseIdlErrors(program.idl);
     EPOCH_DURATION = stakeConnection.config.epochDuration;
 
-    await stakeConnection.depositTokens(undefined, 102);
+    await stakeConnection.depositTokens(undefined, new BN(102));
     stakeAccountAddress = (await stakeConnection.getStakeAccounts(provider.wallet.publicKey))[0].address;
 
   });

--- a/staking/tests/position_lifecycle.ts
+++ b/staking/tests/position_lifecycle.ts
@@ -66,7 +66,7 @@ describe("position_lifecycle", async () => {
   });
 
   it("deposits tokens and locks", async () => {
-    await stakeConnection.depositAndLockTokens(undefined, 200);
+    await stakeConnection.depositAndLockTokens(undefined, new BN(200));
 
     const res = await stakeConnection.getStakeAccounts(owner);
     assert.equal(res.length, 1);

--- a/staking/tests/unlock_api_test.ts
+++ b/staking/tests/unlock_api_test.ts
@@ -39,7 +39,7 @@ describe("unlock_api", async () => {
   });
 
   it("deposit, lock, unlock, same epoch", async () => {
-    await stakeConnection.depositAndLockTokens(undefined, 100);
+    await stakeConnection.depositAndLockTokens(undefined, new BN(100));
 
     const res = await stakeConnection.getStakeAccounts(owner);
     assert.equal(res.length, 1);
@@ -77,7 +77,7 @@ describe("unlock_api", async () => {
     const res = await stakeConnection.getStakeAccounts(owner);
     assert.equal(res.length, 1);
 
-    await stakeConnection.depositAndLockTokens(res[0], 100);
+    await stakeConnection.depositAndLockTokens(res[0], new BN(100));
 
     await assertBalanceMatches(
       stakeConnection,

--- a/staking/tests/utils/before.ts
+++ b/staking/tests/utils/before.ts
@@ -14,6 +14,7 @@ import {
   TOKEN_PROGRAM_ID,
   Token,
   ASSOCIATED_TOKEN_PROGRAM_ID,
+  u64,
 } from "@solana/spl-token";
 import { MintLayout } from "@solana/spl-token";
 import shell from "shelljs";
@@ -142,7 +143,7 @@ export async function requestPythAirdrop(
   destination: PublicKey,
   pythMintAccount: PublicKey,
   pythMintAuthority: Keypair,
-  amount: number,
+  amount: BN,
   connection: Connection
 ) {
   // Testnet airdrop to ensure that the pyth authority can pay for gas
@@ -175,7 +176,7 @@ export async function requestPythAirdrop(
     destinationAta,
     pythMintAuthority.publicKey,
     [],
-    amount
+    new u64(amount.toString())
   );
   transaction.add(mintIx);
 

--- a/staking/tests/voter_weight.ts
+++ b/staking/tests/voter_weight.ts
@@ -73,7 +73,7 @@ describe("voter_weight", async () => {
     errMap = parseIdlErrors(program.idl);
     EPOCH_DURATION = stakeConnection.config.epochDuration;
 
-    await stakeConnection.depositTokens(undefined, 100);
+    await stakeConnection.depositTokens(undefined, new BN(100));
     stakeAccountAddress = (await stakeConnection.getStakeAccounts(provider.wallet.publicKey))[0].address;
 
     voterAccount = (


### PR DESCRIPTION
Previously spl-tokens transfers and mint were done using floating points (`number`).
We want the API to use `BN` internally. The pain point is converting `BN` to the `solana@spl-token`'s native `u64`.
This is done with `new u64(amount.toString())`, resulting in no loss of precision.