### PR TITLE
Refactor api_test.ts to use new functions

### DIFF
--- a/staking/tests/api_test.ts
+++ b/staking/tests/api_test.ts
@@ -1,22 +1,16 @@
-import { Keypair, Connection } from "@solana/web3.js";
+import { Keypair } from "@solana/web3.js";
 import assert from "assert";
-import { StakeConnection, BalanceSummary } from "../app/StakeConnection";
+import { StakeConnection } from "../app/StakeConnection";
 import {
-  requestPythAirdrop,
-  startValidator,
-  createMint,
+  standardSetup,
   readAnchorConfig,
   getPortNumber,
-  initConfig,
   ANCHOR_CONFIG_PATH,
 } from "./utils/before";
-import { Wallet, Provider } from "@project-serum/anchor";
-import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import {} from "../../staking/tests/utils/before";
 import BN from "bn.js";
 import path from "path";
-import { getConnection } from "./utils/before";
-import { expectFail, expectFailApi } from "./utils/utils";
+import { expectFailApi } from "./utils/utils";
 import { assertBalanceMatches } from "./utils/api_utils";
 
 const portNumber = getPortNumber(path.basename(__filename));
@@ -25,79 +19,48 @@ describe("api", async () => {
   const pythMintAccount = new Keypair();
   const pythMintAuthority = new Keypair();
 
-  const alice = new Keypair();
-
-  const config = readAnchorConfig(ANCHOR_CONFIG_PATH);
-
   let stakeConnection: StakeConnection;
 
-  let setupProgram;
   let controller;
+
+  let EPOCH_DURATION;
+  let owner;
 
   after(async () => {
     controller.abort();
   });
 
-  it("deploy program", async () => {
-    ({ controller, program: setupProgram } = await startValidator(
+  before(async () => {
+    const config = readAnchorConfig(ANCHOR_CONFIG_PATH);
+    ({ controller, stakeConnection } = await standardSetup(
       portNumber,
-      config
-    ));
-  });
-
-  it("initializes config", async () => {
-    await setupProgram.provider.connection.requestAirdrop(
-      alice.publicKey,
-      1_000_000_000_000
-    );
-
-    await createMint(
-      setupProgram.provider,
+      config,
       pythMintAccount,
-      pythMintAuthority.publicKey,
-      null,
-      0,
-      TOKEN_PROGRAM_ID
-    );
-
-    await initConfig(setupProgram, pythMintAccount.publicKey);
-  });
-
-  it("alice receive tokens", async () => {
-    await requestPythAirdrop(
-      alice.publicKey,
-      pythMintAccount.publicKey,
       pythMintAuthority,
-      new BN(1000),
-      setupProgram.provider.connection
-    );
+      null,
+      1000
+    ));
+
+    EPOCH_DURATION = stakeConnection.config.epochDuration;
+    owner = stakeConnection.program.provider.wallet.publicKey;
   });
 
-  it("creates StakeConnection", async () => {
-    const connection = getConnection(portNumber);
 
-    stakeConnection = await StakeConnection.createStakeConnection(
-      connection,
-      new Wallet(alice),
-      config.programs.localnet.staking
-    );
-  });
-
-  it("alice create deposit and lock", async () => {
+  it("Deposit and lock", async () => {
     await stakeConnection.depositAndLockTokens(undefined, new BN(600));
   });
 
-  it("find and parse stake accounts", async () => {
-    const res = await stakeConnection.getStakeAccounts(alice.publicKey);
+  it("Find and parse stake accounts", async () => {
+    const res = await stakeConnection.getStakeAccounts(owner);
 
     assert.equal(res.length, 1);
     assert.equal(
       res[0].stakeAccountPositionsJs.owner.toBase58(),
-      alice.publicKey.toBase58()
+      owner.toBase58()
     );
     assert.equal(
       res[0].stakeAccountMetadata.owner.toBase58(),
-      alice.publicKey.toBase58()
+      owner.toBase58()
     );
     assert.equal(
       res[0].stakeAccountPositionsJs.positions[0].amount.toNumber(),
@@ -106,14 +69,14 @@ describe("api", async () => {
     assert.equal(res[0].tokenBalance.toNumber(), 600);
     await assertBalanceMatches(
       stakeConnection,
-      alice.publicKey,
+      owner,
       { locked: { locking: new BN(600) } },
       await stakeConnection.getTime()
     );
 
     await stakeConnection.depositAndLockTokens(res[0], new BN(100));
 
-    const after = await stakeConnection.getStakeAccounts(alice.publicKey);
+    const after = await stakeConnection.getStakeAccounts(owner);
     assert.equal(after.length, 1);
     assert.equal(
       after[0].stakeAccountPositionsJs.positions[1].amount.toNumber(),
@@ -123,14 +86,14 @@ describe("api", async () => {
     // No time has passed, but LOCKING tokens count as locked for the balance summary, so it shows as 700
     await assertBalanceMatches(
       stakeConnection,
-      alice.publicKey,
+      owner,
       { locked: { locking: new BN(700) } },
       await stakeConnection.getTime()
     );
   });
 
-  it("alice unlock too much", async () => {
-    const res = await stakeConnection.getStakeAccounts(alice.publicKey);
+  it("Unlock too much", async () => {
+    const res = await stakeConnection.getStakeAccounts(owner);
     const stakeAccount = res[0];
 
     await expectFailApi(
@@ -140,28 +103,28 @@ describe("api", async () => {
 
     await assertBalanceMatches(
       stakeConnection,
-      alice.publicKey,
+      owner,
       { locked: { locking: new BN(700) } },
       await stakeConnection.getTime()
     );
   });
 
-  it("alice unlock", async () => {
-    const res = await stakeConnection.getStakeAccounts(alice.publicKey);
+  it("Unlock", async () => {
+    const res = await stakeConnection.getStakeAccounts(owner);
     const stakeAccount = res[0];
 
     await stakeConnection.unlockTokens(stakeAccount, new BN(600));
 
     await assertBalanceMatches(
       stakeConnection,
-      alice.publicKey,
+      owner,
       { locked: { locking: new BN(100) }, withdrawable: new BN(600) },
       await stakeConnection.getTime()
     );
   });
 
-  it("alice withdraw too much", async () => {
-    const res = await stakeConnection.getStakeAccounts(alice.publicKey);
+  it("Withdraw too much", async () => {
+    const res = await stakeConnection.getStakeAccounts(owner);
     const stakeAccount = res[0];
 
     await expectFailApi(
@@ -171,20 +134,20 @@ describe("api", async () => {
 
     await assertBalanceMatches(
       stakeConnection,
-      alice.publicKey,
+      owner,
       { locked: { locking: new BN(100) }, withdrawable: new BN(600) },
       await stakeConnection.getTime()
     );
   });
 
-  it("alice withdraw", async () => {
-    const res = await stakeConnection.getStakeAccounts(alice.publicKey);
+  it("Withdraw", async () => {
+    const res = await stakeConnection.getStakeAccounts(owner);
     const stakeAccount = res[0];
     await stakeConnection.withdrawTokens(stakeAccount, new BN(600));
 
     await assertBalanceMatches(
       stakeConnection,
-      alice.publicKey,
+      owner,
       { locked: { locking: new BN(100) } },
       await stakeConnection.getTime()
     );

--- a/staking/tests/utils/before.ts
+++ b/staking/tests/utils/before.ts
@@ -268,7 +268,8 @@ export async function standardSetup(
   config: AnchorConfig,
   pythMintAccount: Keypair,
   pythMintAuthority: Keypair,
-  globalConfig?: GlobalConfig
+  globalConfig?: GlobalConfig,
+  amount?: number
 ) {
   const { controller, program } = await startValidator(portNumber, config);
 
@@ -287,7 +288,7 @@ export async function standardSetup(
     user,
     pythMintAccount.publicKey,
     pythMintAuthority,
-    new BN(200),
+    new BN(amount ? amount : 200),
     program.provider.connection
   );
 


### PR DESCRIPTION
This PR updates `api_test.ts` to use convenience functions from `before.ts`. 