### PR TITLE
Nice toString for PythBalance

### DIFF
--- a/staking/app/pythBalance.ts
+++ b/staking/app/pythBalance.ts
@@ -4,6 +4,7 @@ import assert from "assert";
 export const PYTH_DECIMALS = 6;
 const INTEGER_REGEXP = new RegExp(/^\d+$/);
 const DECIMAL_REGEXP = new RegExp(`^\\d*\\.\\d{1,${PYTH_DECIMALS}}$`);
+const TRAILING_ZEROS = new RegExp(/\.?0+$/);
 
 export class PythBalance {
   integerAmount: BN;
@@ -46,7 +47,11 @@ export class PythBalance {
       .toString()
       .padStart(PYTH_DECIMALS + 1, "0");
     return (
-      padded.slice(0, padded.length - 6) + "." + padded.slice(padded.length - 6)
+      padded.slice(0, padded.length - PYTH_DECIMALS) +
+      ("." + padded.slice(padded.length - PYTH_DECIMALS)).replace(
+        TRAILING_ZEROS,
+        ""
+      )
     );
   }
 

--- a/staking/tests/pyth_balance.ts
+++ b/staking/tests/pyth_balance.ts
@@ -6,61 +6,66 @@ describe("pyth balance tests", async () => {
   it("Tests on 0", async () => {
     let amount = PythBalance.fromString("0");
     assert.equal(amount.toNumber(), 0);
-    assert.equal(amount.toString(), "0.000000");
+    assert.equal(amount.toString(), "0");
     assert(amount.eq(new PythBalance(new BN(0))));
     assert(amount.toBN().eq(new BN(0)));
 
     amount = new PythBalance(new BN(0));
     assert.equal(amount.toNumber(), 0);
-    assert.equal(amount.toString(), "0.000000");
+    assert.equal(amount.toString(), "0");
     assert(amount.eq(new PythBalance(new BN(0))));
     assert(amount.toBN().eq(new BN(0)));
 
     amount = PythBalance.fromNumber(0);
     assert.equal(amount.toNumber(), 0);
-    assert.equal(amount.toString(), "0.000000");
+    assert.equal(amount.toString(), "0");
     assert(amount.eq(new PythBalance(new BN(0))));
     assert(amount.toBN().eq(new BN(0)));
   });
 
   it("Tests on 0.1", async () => {
     let amount = PythBalance.fromString("0.10000");
-    assert.equal(amount.toString(), "0.100000");
+    assert.equal(amount.toString(), "0.1");
     assert(amount.eq(new PythBalance(new BN(100_000))));
     assert(amount.toBN().eq(new BN(100_000)));
 
     amount = PythBalance.fromString("0.1");
-    assert.equal(amount.toString(), "0.100000");
+    assert.equal(amount.toString(), "0.1");
+    assert(amount.eq(new PythBalance(new BN(100_000))));
+    assert(amount.toBN().eq(new BN(100_000)));
+
+    amount = PythBalance.fromString(".1");
+    assert.equal(amount.toString(), "0.1");
     assert(amount.eq(new PythBalance(new BN(100_000))));
     assert(amount.toBN().eq(new BN(100_000)));
 
     amount = new PythBalance(new BN(100_000));
-    assert.equal(amount.toString(), "0.100000");
+    assert.equal(amount.toString(), "0.1");
     assert(amount.eq(new PythBalance(new BN(100_000))));
     assert(amount.toBN().eq(new BN(100_000)));
   });
 
   it("Tests on 100", async () => {
     let amount = PythBalance.fromString("100.0");
-    assert.equal(amount.toString(), "100.000000");
+    assert.equal(amount.toString(), "100");
     assert.equal(amount.toNumber(), 100);
     assert(amount.eq(new PythBalance(new BN(100_000_000))));
     assert(amount.toBN().eq(new BN(100_000_000)));
 
     amount = PythBalance.fromString("100");
-    assert.equal(amount.toString(), "100.000000");
+    assert.equal(amount.toString(), "100");
     assert.equal(amount.toNumber(), 100);
     assert(amount.eq(new PythBalance(new BN(100_000_000))));
     assert(amount.toBN().eq(new BN(100_000_000)));
 
     amount = new PythBalance(new BN(100_000_000));
-    assert.equal(amount.toString(), "100.000000");
+    assert.equal(amount.toString(), "100");
     assert.equal(amount.toNumber(), 100);
     assert(amount.eq(new PythBalance(new BN(100_000_000))));
     assert(amount.toBN().eq(new BN(100_000_000)));
 
     amount = PythBalance.fromNumber(100);
-    assert.equal(amount.toString(), "100.000000");
+    assert.equal(amount.toString(), "100");
     assert.equal(amount.toNumber(), 100);
     assert(amount.eq(new PythBalance(new BN(100_000_000))));
     assert(amount.toBN().eq(new BN(100_000_000)));


### PR DESCRIPTION
`toString` now gets rid of trailing zeros. Has a behavior closer to printing a `number`.