### PR TITLE
Make localnet governance a little easier to use

### DIFF
--- a/staking/tests/utils/before.ts
+++ b/staking/tests/utils/before.ts
@@ -409,7 +409,7 @@ export async function standardSetup(
     const { realm, governance } = await createGovernance(
       program.provider,
       config,
-      globalConfig.epochDuration.toNumber(),
+      Math.max(globalConfig.epochDuration.toNumber(), 60), // at least one minute
       pythMintAccount.publicKey
     );
     globalConfig.governanceAuthority = governance;


### PR DESCRIPTION
Make the setup script create a treasury for governance so that we actually have something to make proposals about. Also set a minimum voting time of 1 minute on localnet. Previously it was 1 epoch, which is 1 second on localnet.