### PR TITLE
Feature/vesting schedule users api

### DIFF
--- a/staking/app/StakeConnection.ts
+++ b/staking/app/StakeConnection.ts
@@ -478,7 +478,7 @@ export class StakeConnection {
    * if it exists.
    * TODO : Function for opting out of governance
    */
-  public async OptIntoGovernance(stakeAccount: StakeAccount) {
+  public async optIntoGovernance(stakeAccount: StakeAccount) {
     const owner: PublicKey = stakeAccount.stakeAccountMetadata.owner;
 
     const unvestedBalance = stakeAccount.getBalanceSummary(

--- a/staking/tests/vesting_test.ts
+++ b/staking/tests/vesting_test.ts
@@ -117,7 +117,7 @@ describe("vesting", async () => {
     );
 
     // Sam opts into governance
-    await samConnection.OptIntoGovernance(stakeAccount);
+    await samConnection.optIntoGovernance(stakeAccount);
 
     stakeAccount = await samConnection.getMainAccount(sam.publicKey);
     assert(stakeAccount.hasUnvestedTokens(await samConnection.getTime()));


### PR DESCRIPTION
This PR introduces the API functions for vesting accounts (account with a vesting schedule).

Revised logic : 
- `optIntoGovernance` function. This function can get called on any staking account. It will create the spl-governance record for the user if it doesn't exist. For vesting accounts, it will also stake the entirety of the unvested balance.

Good states :
- Any account with no unvested tokens and has a spl-governance record
- Any account with unvested tokens and such that `getInactiveUnvestedTokens` is 0 (all unvested tokens are staked) and has a spl-governance record (Governance OPT IN)
- Any account with unvested tokens and such that `getGovernanceExposure` is 0 (0 tokens are staked) (Governance OPT OUT)

It you only use the frontend, you are always in a Good state.

Recoverable states:
- Good states that don't have a spl-governance record (recovered by getting one by calling `optIntoGovernance`)

Unrecoverable states (identified by `hasBrokenState` right now)
- An account with unvested tokens such that some unvested tokens are staked but not all of them.
Some of these states can be reached by direct interaction with the onchain program.
Example account :
- 3 unvested tokens
- 1 is UNLOCKING, 2 are LOCKED
The user here has only 2 voting power. This state is unreachable from the UI because it will never let you unlock unvested tokens. Repairing this account requires waiting until the 1 token becomes unlocked and then locking it. Or starting to unlock the 2 locked tokens and wait until everything is unstaked.

Proposal : Repair account means unlocking all positions.