### PR TITLE
Return the voter weight pubkeys

### DIFF
--- a/staking/app/StakeConnection.ts
+++ b/staking/app/StakeConnection.ts
@@ -365,19 +365,25 @@ export class StakeConnection {
   public async withUpdateVoterWeight(
     instructions: TransactionInstruction[],
     stakeAccount: StakeAccount
-  ) {
-    instructions.push(
-      await this.program.methods
-        .updateVoterWeight()
-        .accounts({ stakeAccountPositions: stakeAccount.address })
-        .instruction()
-    );
-    instructions.push(
-      await this.program.methods
-        .updateMaxVoterWeight()
-        .accounts({ governanceAccount: this.votingProductMetadataAccount })
-        .instruction()
-    );
+  ): Promise<{
+    voterWeightAccount: PublicKey;
+    maxVoterWeightAccount: PublicKey;
+  }> {
+    const updateVoterWeightIx = this.program.methods
+      .updateVoterWeight()
+      .accounts({ stakeAccountPositions: stakeAccount.address });
+    instructions.push(await updateVoterWeightIx.instruction());
+
+    const updateMaxVoterWeightIx = this.program.methods
+      .updateMaxVoterWeight()
+      .accounts({ governanceAccount: this.votingProductMetadataAccount });
+    instructions.push(await updateMaxVoterWeightIx.instruction());
+
+    return {
+      voterWeightAccount: (await updateVoterWeightIx.pubkeys()).voterRecord,
+      maxVoterWeightAccount: (await updateMaxVoterWeightIx.pubkeys())
+        .maxVoterRecord,
+    };
   }
 
   public async withCreateAccount(

--- a/staking/tests/utils/api_utils.ts
+++ b/staking/tests/utils/api_utils.ts
@@ -78,7 +78,10 @@ export async function assertVoterWeightEquals(
   const actual = stakeAccount.getVoterWeight(await stakeConnection.getTime());
   assert(actual.eq(expected.voterWeight));
   const tx = new Transaction();
-  stakeConnection.withUpdateVoterWeight(tx.instructions, stakeAccount);
+  const accounts = await stakeConnection.withUpdateVoterWeight(
+    tx.instructions,
+    stakeAccount
+  );
   await stakeConnection.program.provider.sendAndConfirm(tx, []);
 
   let [voterAccount, voterBump] = await PublicKey.findProgramAddress(
@@ -88,6 +91,7 @@ export async function assertVoterWeightEquals(
     ],
     stakeConnection.program.programId
   );
+  assert.equal(accounts.voterWeightAccount.toBase58(), voterAccount.toBase58());
 
   const voterRecord =
     await stakeConnection.program.account.voterWeightRecord.fetch(voterAccount);
@@ -98,6 +102,10 @@ export async function assertVoterWeightEquals(
       [anchor.utils.bytes.utf8.encode(wasm.Constants.MAX_VOTER_RECORD_SEED())],
       stakeConnection.program.programId
     );
+  assert.equal(
+    accounts.maxVoterWeightAccount.toBase58(),
+    maxVoterWeightAccount.toBase58()
+  );
 
   const maxVoterWeightRecord =
     await stakeConnection.program.account.maxVoterWeightRecord.fetch(

--- a/staking/yarn.lock
+++ b/staking/yarn.lock
@@ -1324,10 +1324,10 @@ prettier@^2.6.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
   integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
-pyth-staking-wasm@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/pyth-staking-wasm/-/pyth-staking-wasm-0.2.1.tgz#9da53e4ef7aa409c8b3623ffd83c789bc83dd01a"
-  integrity sha512-z3B+W+n4Gi+PqTEocqgZ8TvQrt3HCv/zaVIdF1g2B1+GkOSALH0cD08z33vz1T4fntfcm2/0FbLAkPL36ldzHQ==
+pyth-staking-wasm@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/pyth-staking-wasm/-/pyth-staking-wasm-0.2.2.tgz#588de9dcc0198338b224f335136e0a1758e26577"
+  integrity sha512-F3JwGHlRLdEk3rY0WhO1wrmYwwassk2HkQdcHgfoOGYqpuj+Bl9rFfqGD7akA0qL3OoKs0DAqkscISGLP/DHPQ==
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
We need the address of the voter weight and max voter weight accounts for the UI, so we should just return them from the API where we have them. This uses the new Anchor `.pubkeys` feature, since we don't care about the bump seed.