### PR TITLE
Extra mock clock check

### DIFF
--- a/staking/app/scripts/devnet_upgrade.ts
+++ b/staking/app/scripts/devnet_upgrade.ts
@@ -196,6 +196,12 @@ async function upgradeProgram(
 ) {
   // The web3.js functions for interacting with the upgradeable loader are extremely primitive
   console.log("Upgrading program at %s", connection.rpcEndpoint);
+  const grepResults = shell.exec(`grep -q MOCK_CLOCK_ENABLED ${soPath}`);
+  const GREP_LINES_FOUND = 0;
+  if (grepResults.code == GREP_LINES_FOUND) {
+    console.error("Grep found MOCK_CLOCK_ENABLED in the binary. Aborting.");
+    throw new Error("Refusing to deploy binary with mock clock enabled");
+  }
   shell.exec(
     `solana program deploy ${soPath} --program-id ${DEVNET_STAKING_ADDRESS.toBase58()} -u ${
       connection.rpcEndpoint

--- a/staking/app/scripts/devnet_upgrade.ts
+++ b/staking/app/scripts/devnet_upgrade.ts
@@ -197,8 +197,8 @@ async function upgradeProgram(
   // The web3.js functions for interacting with the upgradeable loader are extremely primitive
   console.log("Upgrading program at %s", connection.rpcEndpoint);
   const grepResults = shell.exec(`grep -q MOCK_CLOCK_ENABLED ${soPath}`);
-  const GREP_LINES_FOUND = 0;
-  if (grepResults.code == GREP_LINES_FOUND) {
+  const GREP_SUCCESS = 0;
+  if (grepResults.code == GREP_SUCCESS) {
     console.error("Grep found MOCK_CLOCK_ENABLED in the binary. Aborting.");
     throw new Error("Refusing to deploy binary with mock clock enabled");
   }

--- a/staking/programs/staking/src/lib.rs
+++ b/staking/programs/staking/src/lib.rs
@@ -44,7 +44,6 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 pub const GOVERNANCE_PROGRAM: Pubkey = pubkey!("GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw");
 
-
 #[program]
 pub mod staking {
 
@@ -493,6 +492,9 @@ pub mod staking {
         {
             let config = &mut ctx.accounts.config;
             config.mock_clock_time = config.mock_clock_time.checked_add(seconds).unwrap();
+            // This assert can't possibly fail, but this gets the string "MOCK_CLOCK_ENABLED"
+            // into the binary. Before we deploy, we check for this string and abort the deployment.
+            assert!(config.mock_clock_time.to_string() != "MOCK_CLOCK_ENABLED");
             Ok(())
         }
         #[cfg(not(feature = "mock-clock"))]

--- a/staking/tests/clock_api_test.ts
+++ b/staking/tests/clock_api_test.ts
@@ -68,8 +68,8 @@ describe("clock_api", async () => {
     const grepResults = shell.exec(
       `grep -q MOCK_CLOCK_ENABLED ${config.path.binary_path}`
     );
-    const GREP_LINES_FOUND = 0;
-    assert.equal(grepResults.code, GREP_LINES_FOUND);
+    const GREP_SUCCESS = 0;
+    assert.equal(grepResults.code, GREP_SUCCESS);
   });
 
   after(async () => {

--- a/staking/tests/clock_api_test.ts
+++ b/staking/tests/clock_api_test.ts
@@ -1,4 +1,5 @@
 import {
+  AnchorConfig,
   ANCHOR_CONFIG_PATH,
   CustomAbortController,
   getPortNumber,
@@ -11,6 +12,7 @@ import { Keypair } from "@solana/web3.js";
 import { StakeConnection } from "../app";
 import assert from "assert";
 import { BN } from "@project-serum/anchor";
+import shell from "shelljs";
 
 const portNumber = getPortNumber(path.basename(__filename));
 
@@ -23,8 +25,9 @@ describe("clock_api", async () => {
 
   const CLOCK_TOLERANCE_SECONDS = 10;
 
+  let config: AnchorConfig;
   before(async () => {
-    const config = readAnchorConfig(ANCHOR_CONFIG_PATH);
+    config = readAnchorConfig(ANCHOR_CONFIG_PATH);
     ({ controller, stakeConnection } = await standardSetup(
       portNumber,
       config,
@@ -59,6 +62,14 @@ describe("clock_api", async () => {
     sysTime = Date.now() / 1000;
     solanaTime = (await stakeConnection.getTime()).toNumber();
     assert.ok(Math.abs(sysTime - solanaTime) < CLOCK_TOLERANCE_SECONDS);
+  });
+
+  it("checks that because mock clock is enabled, deployment will fail", async () => {
+    const grepResults = shell.exec(
+      `grep -q MOCK_CLOCK_ENABLED ${config.path.binary_path}`
+    );
+    const GREP_LINES_FOUND = 0;
+    assert.equal(grepResults.code, GREP_LINES_FOUND);
   });
 
   after(async () => {


### PR DESCRIPTION
One thing we had in clickup was to make sure we didn't deploy with mock clock enabled. We had the runtime check, but it wasn't obvious how to do it at deploy time. This solves that problem.

The rust compiler is pretty aggressive and will delete variables that are not referenced, so this bogus assert was the best I could come up with. Declaring a constant string did not work.