### PR TITLE
Allow large errors

### DIFF
--- a/staking/programs/staking/src/lib.rs
+++ b/staking/programs/staking/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(unused_must_use)]
 #![allow(dead_code)]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::result_large_err)]
 // Objects of type Result must be used, otherwise we might
 // call a function that returns a Result and not handle the error
 


### PR DESCRIPTION
This new clippy warning was raising warnings on `AnchorError`.