### PR TITLE
Use local idl

### DIFF
--- a/staking/app/StakeConnection.ts
+++ b/staking/app/StakeConnection.ts
@@ -1,5 +1,4 @@
 import {
-  Provider,
   Program,
   Wallet,
   utils,
@@ -27,6 +26,7 @@ import {
 import BN from "bn.js";
 import * as idljs from "@project-serum/anchor/dist/cjs/coder/borsh/idl";
 import { Staking } from "../target/types/staking";
+import IDL from "../target/idl/staking.json";
 import { batchInstructions } from "./transaction";
 import { PythBalance } from "./pythBalance";
 import {
@@ -36,7 +36,7 @@ import {
 } from "@solana/spl-governance";
 import { GOVERNANCE_ADDRESS } from "./constants";
 import assert from "assert";
-import { PositionAccountJs, Position } from "./PositionAccountJs";
+import { PositionAccountJs } from "./PositionAccountJs";
 let wasm = wasm2;
 export { wasm };
 
@@ -83,9 +83,8 @@ export class StakeConnection {
     stakingProgramAddress: PublicKey
   ): Promise<StakeConnection> {
     const provider = new AnchorProvider(connection, wallet, {});
-    const idl = (await Program.fetchIdl(stakingProgramAddress, provider))!;
     const program = new Program(
-      idl,
+      IDL as Idl,
       stakingProgramAddress,
       provider
     ) as unknown as Program<Staking>;

--- a/staking/app/deploy/4_transfer_authorities_to_multisig.ts
+++ b/staking/app/deploy/4_transfer_authorities_to_multisig.ts
@@ -12,7 +12,9 @@ import {
 } from "./mainnet_beta";
 
 import { GOVERNANCE_ADDRESS, REALM_ID, STAKING_ADDRESS } from "../constants";
-import { AnchorProvider, Program, Wallet } from "@project-serum/anchor";
+import { AnchorProvider, Idl, Program, Wallet } from "@project-serum/anchor";
+import IDL from "../../target/idl/staking.json";
+
 // Actual transaction hash :
 // mainnet-beta : 3FDjeBC946SZ6ZgSiDiNzFHKS5hs9bAXYrJKGZrGw1tuVcwi4BxXB1qvqsVmvtcnG5mzYvLM4hmPLjUTiCiY6Tfe
 // devnet : 54WrJp6FDXvJCVzaGojUtWz4brm8wJHx3ZTYCpSTF2EwmeswySYsQY335XhJ1A7KL2N4mhYW7NtAGJpMA2fM9M6W
@@ -24,8 +26,8 @@ async function main() {
     new Wallet(AUTHORITY_KEYPAIR),
     {}
   );
-  const idl = (await Program.fetchIdl(STAKING_ADDRESS, provider))!;
-  const program = new Program(idl, STAKING_ADDRESS, provider);
+
+  const program = new Program(IDL as Idl, STAKING_ADDRESS, provider);
 
   const tx = new Transaction();
   withSetRealmAuthority(

--- a/staking/tsconfig.api.json
+++ b/staking/tsconfig.api.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "lib",
-    "declaration": true
+    "declaration": true,
+    "resolveJsonModule": true
   },
   "include": ["./app/*.ts"],
   "exclude": ["./tests", "./docker", "./migrations"]

--- a/staking/tsconfig.json
+++ b/staking/tsconfig.json
@@ -5,7 +5,8 @@
     "module": "commonjs",
     "target": "es6",
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
   "include": ["./app/*.ts", "./tests"],
   "exclude": ["./docker", "./migrations"]


### PR DESCRIPTION
I prefer using the locally generated IDL than the on-chain IDL. 
It feels more secure since the on-chain IDL can be upgraded.
Explorer will still use the on-chain IDL.