### PR TITLE
Split accounts test

### DIFF
--- a/staking/programs/staking/src/error.rs
+++ b/staking/programs/staking/src/error.rs
@@ -69,11 +69,11 @@ pub enum ErrorCode {
     SplitZeroTokens,
     #[msg("Can't split more tokens than are in the account")] // 6032
     SplitTooManyTokens,
-    #[msg("Sanity check failed")] // 6033
-    SanityCheckFailed,
-    #[msg("Other")] //6034
-    Other,
     #[msg("Can't split a token account with staking positions. Unstake your tokens first.")]
-    // 6035
+    // 6033
     SplitWithStake,
+    #[msg("Sanity check failed")] // 6034
+    SanityCheckFailed,
+    #[msg("Other")] //6035
+    Other,
 }

--- a/staking/programs/staking/src/error.rs
+++ b/staking/programs/staking/src/error.rs
@@ -71,6 +71,8 @@ pub enum ErrorCode {
     SplitTooManyTokens,
     #[msg("Sanity check failed")] // 6033
     SanityCheckFailed,
-    #[msg("Other")] //6031
+    #[msg("Other")] //6034
     Other,
+    #[msg("Can't split a token account with staking positions. Unstake your tokens first.")] // 6035
+    SplitWithStake,
 }

--- a/staking/programs/staking/src/error.rs
+++ b/staking/programs/staking/src/error.rs
@@ -73,6 +73,7 @@ pub enum ErrorCode {
     SanityCheckFailed,
     #[msg("Other")] //6034
     Other,
-    #[msg("Can't split a token account with staking positions. Unstake your tokens first.")] // 6035
+    #[msg("Can't split a token account with staking positions. Unstake your tokens first.")]
+    // 6035
     SplitWithStake,
 }

--- a/staking/programs/staking/src/lib.rs
+++ b/staking/programs/staking/src/lib.rs
@@ -607,6 +607,11 @@ pub mod staking {
             config.unlocking_duration,
         )?;
 
+        // Check that there aren't any positions (i.e., staked tokens) in the source account.
+        // This check allows us to create an empty positions account on behalf of the recipient and
+        // not worry about moving positions from the source account to the new account.
+        require!(source_stake_account_positions.num_positions()? == 0, ErrorCode::SplitWithStake);
+
         require!(split_request.amount > 0, ErrorCode::SplitZeroTokens);
         require!(
             split_request.amount < source_stake_account_custody.amount,
@@ -625,18 +630,6 @@ pub mod staking {
             )?;
         source_stake_account_metadata.set_lock(source_vesting_account);
         new_stake_account_metadata.set_lock(new_vesting_account);
-
-        // Split positions
-        source_stake_account_positions.split(
-            new_stake_account_positions,
-            &mut source_stake_account_metadata.next_index,
-            &mut new_stake_account_metadata.next_index,
-            remaining_amount,
-            split_request.amount,
-            source_stake_account_custody.amount,
-            current_epoch,
-            config.unlocking_duration,
-        )?;
 
 
         {

--- a/staking/programs/staking/src/lib.rs
+++ b/staking/programs/staking/src/lib.rs
@@ -611,7 +611,7 @@ pub mod staking {
         // This check allows us to create an empty positions account on behalf of the recipient and
         // not worry about moving positions from the source account to the new account.
         require!(
-            source_stake_account_positions.num_positions()? == 0,
+            source_stake_account_metadata.next_index == 0,
             ErrorCode::SplitWithStake
         );
 

--- a/staking/programs/staking/src/lib.rs
+++ b/staking/programs/staking/src/lib.rs
@@ -610,7 +610,10 @@ pub mod staking {
         // Check that there aren't any positions (i.e., staked tokens) in the source account.
         // This check allows us to create an empty positions account on behalf of the recipient and
         // not worry about moving positions from the source account to the new account.
-        require!(source_stake_account_positions.num_positions()? == 0, ErrorCode::SplitWithStake);
+        require!(
+            source_stake_account_positions.num_positions()? == 0,
+            ErrorCode::SplitWithStake
+        );
 
         require!(split_request.amount > 0, ErrorCode::SplitZeroTokens);
         require!(

--- a/staking/programs/staking/src/state/positions.rs
+++ b/staking/programs/staking/src/state/positions.rs
@@ -114,16 +114,6 @@ impl PositionData {
         }
         Ok(exposure)
     }
-
-    pub fn num_positions(&self) -> Result<usize> {
-        let mut count: usize = 0;
-        for i in 0..MAX_POSITIONS {
-            if let Some(_p) = self.read_position(i)? {
-                count += 1;
-            }
-        }
-        Ok(count)
-    }
 }
 
 pub trait TryBorsh {
@@ -447,7 +437,6 @@ pub mod tests {
             return res;
         }
     }
-
 
     #[quickcheck]
     fn prop(input: Vec<DataOperation>) -> bool {

--- a/staking/target/idl/staking.json
+++ b/staking/target/idl/staking.json
@@ -1916,6 +1916,11 @@
       "code": 6034,
       "name": "Other",
       "msg": "Other"
+    },
+    {
+      "code": 6035,
+      "name": "SplitWithStake",
+      "msg": "Can't split a token account with staking positions. Unstake your tokens first."
     }
   ]
 }

--- a/staking/target/types/staking.ts
+++ b/staking/target/types/staking.ts
@@ -1916,6 +1916,11 @@ export type Staking = {
       "code": 6034,
       "name": "Other",
       "msg": "Other"
+    },
+    {
+      "code": 6035,
+      "name": "SplitWithStake",
+      "msg": "Can't split a token account with staking positions. Unstake your tokens first."
     }
   ]
 };
@@ -3838,6 +3843,11 @@ export const IDL: Staking = {
       "code": 6034,
       "name": "Other",
       "msg": "Other"
+    },
+    {
+      "code": 6035,
+      "name": "SplitWithStake",
+      "msg": "Can't split a token account with staking positions. Unstake your tokens first."
     }
   ]
 };


### PR DESCRIPTION
two changes per our conversation:

1. disallow splitting accounts that have positions. This means you have to unstake before you can split.
2. test the vesting account splitting logic.

I didn't add the check that all tokens in the account are locked because it turns out that check doesn't help with the vesting account splitting logic.