### PR TITLE
Add scaling factor to convert from voter weight to staked tokens

### DIFF
--- a/staking/app/StakeConnection.ts
+++ b/staking/app/StakeConnection.ts
@@ -132,8 +132,6 @@ export class StakeConnection {
       await program.provider.connection.getAccountInfo(
         votingProductMetadataAccount
       );
-    console.log(votingProductMetadataAccountData);
-    console.log(votingProductMetadataAccountData!.data);
     const votingAccountMetadataWasm = new wasm.WasmTargetMetadata(
       votingProductMetadataAccountData!.data
     );
@@ -976,9 +974,8 @@ export class StakeConnection {
         .rpc();
     }
   }
-
-  public async;
 }
+
 export interface BalanceSummary {
   withdrawable: PythBalance;
   // We may break this down into active, warmup, and cooldown in the future

--- a/staking/app/StakeConnection.ts
+++ b/staking/app/StakeConnection.ts
@@ -975,6 +975,10 @@ export class StakeConnection {
     }
   }
 
+  /**
+   * This returns the current scaling factor between staked tokens and realms voter weight.
+   * The formula is n_staked_tokens = scaling_factor * n_voter_weight
+   */
   public getScalingFactor(): number {
     let currentEpoch = new BN(Date.now() / 1000).div(this.config.epochDuration);
     let currentAmountLocked = Number(

--- a/staking/app/StakeConnection.ts
+++ b/staking/app/StakeConnection.ts
@@ -59,6 +59,7 @@ export class StakeConnection {
   configAddress: PublicKey;
   votingProductMetadataAccount: PublicKey;
   votingProduct = { voting: {} };
+  votingAccountMetadataWasm: any;
   governanceAddress: PublicKey;
 
   private constructor(
@@ -66,7 +67,8 @@ export class StakeConnection {
     provider: AnchorProvider,
     config: GlobalConfig,
     configAddress: PublicKey,
-    votingProductMetadataAccount: PublicKey
+    votingProductMetadataAccount: PublicKey,
+    votingAccountMetadataWasm: any
   ) {
     this.program = program;
     this.provider = provider;
@@ -74,6 +76,7 @@ export class StakeConnection {
     this.configAddress = configAddress;
     this.votingProductMetadataAccount = votingProductMetadataAccount;
     this.governanceAddress = GOVERNANCE_ADDRESS();
+    this.votingAccountMetadataWasm = votingAccountMetadataWasm;
   }
 
   public static async connect(
@@ -125,12 +128,23 @@ export class StakeConnection {
       )
     )[0];
 
+    const votingProductMetadataAccountData =
+      await program.provider.connection.getAccountInfo(
+        votingProductMetadataAccount
+      );
+    console.log(votingProductMetadataAccountData);
+    console.log(votingProductMetadataAccountData!.data);
+    const votingAccountMetadataWasm = new wasm.WasmTargetMetadata(
+      votingProductMetadataAccountData!.data
+    );
+
     return new StakeConnection(
       program,
       provider,
       config,
       configAddress,
-      votingProductMetadataAccount
+      votingProductMetadataAccount,
+      votingAccountMetadataWasm
     );
   }
 
@@ -882,7 +896,7 @@ export class StakeConnection {
     recipient: PublicKey
   ) {
     const preInstructions = [
-      ComputeBudgetProgram.setComputeUnitLimit({ units: 20000 }),
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 30000 }),
       ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 30101 }),
     ];
     await this.program.methods
@@ -962,6 +976,8 @@ export class StakeConnection {
         .rpc();
     }
   }
+
+  public async;
 }
 export interface BalanceSummary {
   withdrawable: PythBalance;

--- a/staking/app/StakeConnection.ts
+++ b/staking/app/StakeConnection.ts
@@ -974,6 +974,16 @@ export class StakeConnection {
         .rpc();
     }
   }
+
+  public getScalingFactor(): number {
+    let currentEpoch = new BN(Date.now() / 1000).div(this.config.epochDuration);
+    let currentAmountLocked = Number(
+      this.votingAccountMetadataWasm.getCurrentAmountLocked(
+        BigInt(currentEpoch.toString())
+      )
+    );
+    return currentAmountLocked / Number(wasm.Constants.MAX_VOTER_WEIGHT());
+  }
 }
 
 export interface BalanceSummary {

--- a/staking/package.json
+++ b/staking/package.json
@@ -38,7 +38,7 @@
     "wasm-pack": "^0.10.2"
   },
   "scripts": {
-    "test": "npm run build_wasm && anchor build -- --features mock-clock && npm run dump_governance && ts-mocha --parallel -p ./tsconfig.json -t 1000000 tests/*.ts",
+    "test": "npm run build_wasm && anchor build -- --features mock-clock && npm run dump_governance && ts-mocha --parallel -p ./tsconfig.json -t 1000000 tests/voter_weight_test.ts",
     "build": "npm run build_wasm && tsc -p tsconfig.api.json",
     "build_wasm": "./scripts/build_wasm.sh",
     "localnet": "anchor build && npm run dump_governance && ts-node ./app/scripts/localnet.ts",

--- a/staking/package.json
+++ b/staking/package.json
@@ -38,7 +38,7 @@
     "wasm-pack": "^0.10.2"
   },
   "scripts": {
-    "test": "npm run build_wasm && anchor build -- --features mock-clock && npm run dump_governance && ts-mocha --parallel -p ./tsconfig.json -t 1000000 tests/voter_weight_test.ts",
+    "test": "npm run build_wasm && anchor build -- --features mock-clock && npm run dump_governance && ts-mocha --parallel -p ./tsconfig.json -t 1000000 tests/*.ts",
     "build": "npm run build_wasm && tsc -p tsconfig.api.json",
     "build_wasm": "./scripts/build_wasm.sh",
     "localnet": "anchor build && npm run dump_governance && ts-node ./app/scripts/localnet.ts",


### PR DESCRIPTION
In the Pyth Realm only staked tokens can vote and the voting power of each staked token is inversely proportional to how many tokens are currently staked (so that at any time the sum of the power of all staked tokens is equal to the total voting power of 10 Billion).
In the UI, voting power gets displayed, leading to a lot of confusion in the DAO.
It would be better to do a change of unit and display things as the number of staked tokens.
This PR is exposing the scaling factor.
