### PR TITLE
[frontend] Fix balance regex

### DIFF
--- a/frontend/utils/validAmountChange.ts
+++ b/frontend/utils/validAmountChange.ts
@@ -1,5 +1,5 @@
 export function validAmountChange(amount: string): boolean {
-  const re = /^(\d*\.)?\d{0,6}$/
+  const re = /^\d*\.?\d{0,6}$/
   if (re.test(amount)) {
     return true
   }


### PR DESCRIPTION
This regex error was making it impossible to stake more than `999999` tokens at a time unless you added decimals.