### PR TITLE
[frontend] Try to fix API

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,12 +15,12 @@ module.exports = {
   webpack(config, { isServer }) {
     config.experiments = { asyncWebAssembly: true, layers: true }
     // This is hack to fix the import of the wasm files https://github.com/vercel/next.js/issues/25852
-    if (isServer) {
-      config.output.webassemblyModuleFilename =
-        './../static/wasm/[modulehash].wasm'
-    } else {
-      config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'
-    }
+    // if (isServer) {
+    //   config.output.webassemblyModuleFilename =
+    //     './../static/wasm/[modulehash].wasm'
+    // } else {
+    config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'
+    // }
     config.optimization.moduleIds = 'named'
     // End of hack
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -12,14 +12,12 @@ module.exports = {
     ENDPOINT: process.env.ENDPOINT,
     CLUSTER: process.env.CLUSTER,
   },
-  webpack(config, { isServer }) {
+  webpack(config, { isServer, dev }) {
     config.experiments = { asyncWebAssembly: true, layers: true }
     // This is hack to fix the import of the wasm files https://github.com/vercel/next.js/issues/25852
-    if (isServer) {
-      config.output.webassemblyModuleFilename =
-        './../static/wasm/[modulehash].wasm'
-    } else {
-      config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'
+    if (!dev && isServer) {
+      config.output.webassemblyModuleFilename = 'chunks/[id].wasm'
+      config.plugins.push(new WasmChunksFixPlugin())
     }
     config.optimization.moduleIds = 'named'
     // End of hack
@@ -31,4 +29,23 @@ module.exports = {
     }
     return config
   },
+}
+
+class WasmChunksFixPlugin {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap('WasmChunksFixPlugin', (compilation) => {
+      compilation.hooks.processAssets.tap(
+        { name: 'WasmChunksFixPlugin' },
+        (assets) =>
+          Object.entries(assets).forEach(([pathname, source]) => {
+            if (!pathname.match(/\.wasm$/)) return
+            compilation.deleteAsset(pathname)
+
+            const name = pathname.split('/')[1]
+            const info = compilation.assetsInfo.get(pathname)
+            compilation.emitAsset(name, source, info)
+          })
+      )
+    })
+  }
 }

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,12 +15,12 @@ module.exports = {
   webpack(config, { isServer }) {
     config.experiments = { asyncWebAssembly: true, layers: true }
     // This is hack to fix the import of the wasm files https://github.com/vercel/next.js/issues/25852
-    // if (isServer) {
-    //   config.output.webassemblyModuleFilename =
-    //     './../static/wasm/[modulehash].wasm'
-    // } else {
-    config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'
-    // }
+    if (isServer) {
+      config.output.webassemblyModuleFilename =
+        './../static/wasm/[modulehash].wasm'
+    } else {
+      config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'
+    }
     config.optimization.moduleIds = 'named'
     // End of hack
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -12,13 +12,16 @@ module.exports = {
     ENDPOINT: process.env.ENDPOINT,
     CLUSTER: process.env.CLUSTER,
   },
-  webpack(config, { isServer, dev }) {
+  webpack(config, { isServer }) {
     config.experiments = { asyncWebAssembly: true, layers: true }
     // This is hack to fix the import of the wasm files https://github.com/vercel/next.js/issues/25852
-    if (!dev && isServer) {
-      config.output.webassemblyModuleFilename = 'chunks/[id].wasm'
-      config.plugins.push(new WasmChunksFixPlugin())
+    if (isServer) {
+      config.output.webassemblyModuleFilename =
+        './../static/wasm/[modulehash].wasm'
+    } else {
+      config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'
     }
+    config.optimization.moduleIds = 'named'
     // End of hack
 
     // Import the browser version of wasm instead of the node version
@@ -28,23 +31,4 @@ module.exports = {
     }
     return config
   },
-}
-
-class WasmChunksFixPlugin {
-  apply(compiler) {
-    compiler.hooks.thisCompilation.tap('WasmChunksFixPlugin', (compilation) => {
-      compilation.hooks.processAssets.tap(
-        { name: 'WasmChunksFixPlugin' },
-        (assets) =>
-          Object.entries(assets).forEach(([pathname, source]) => {
-            if (!pathname.match(/\.wasm$/)) return
-            compilation.deleteAsset(pathname)
-
-            const name = pathname.split('/')[1]
-            const info = compilation.assetsInfo.get(pathname)
-            compilation.emitAsset(name, source, info)
-          })
-      )
-    })
-  }
 }

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -19,7 +19,6 @@ module.exports = {
       config.output.webassemblyModuleFilename = 'chunks/[id].wasm'
       config.plugins.push(new WasmChunksFixPlugin())
     }
-    config.optimization.moduleIds = 'named'
     // End of hack
 
     // Import the browser version of wasm instead of the node version

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@solana/wallet-adapter-wallets": "^0.19.16",
     "@solana/web3.js": "^1.87.5",
     "@tippyjs/react": "^4.2.6",
+    "axios": "^1.6.7",
     "dotenv": "^16.0.0",
     "next": "12.2.5",
     "prop-types": "^15.8.1",

--- a/frontend/pages/api/getAllStakingAccounts.ts
+++ b/frontend/pages/api/getAllStakingAccounts.ts
@@ -1,0 +1,32 @@
+import { bs58 } from '@coral-xyz/anchor/dist/cjs/utils/bytes'
+import { PublicKey } from '@solana/web3.js'
+import axios from 'axios'
+
+// The JSON payload is too big when using the @solana/web3.js getProgramAccounts
+// We get around this by using the base64+ztsd encoding instead of base64 that @solana/web3.js uses
+export async function getAllStakeAccounts(url: string): Promise<PublicKey[]> {
+  const response = await axios({
+    method: 'post',
+    url: url,
+    data: {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'getProgramAccounts',
+      params: [
+        'pytS9TjG1qyAZypk7n8rw8gfW9sUaqqYyMhJQ4E7JCQ',
+        {
+          encoding: 'base64+zstd',
+          filters: [
+            {
+              memcmp: {
+                offset: 0,
+                bytes: bs58.encode(Buffer.from('55c3f14f7cc04f0b', 'hex')), // Positions account discriminator
+              },
+            },
+          ],
+        },
+      ],
+    },
+  })
+  return response.data.result.map((x: any) => new PublicKey(x.pubkey))
+}

--- a/frontend/pages/api/getAllStakingAccounts.ts
+++ b/frontend/pages/api/getAllStakingAccounts.ts
@@ -5,7 +5,6 @@ import axios from 'axios'
 // The JSON payload is too big when using the @solana/web3.js getProgramAccounts
 // We get around this by using the base64+ztsd encoding instead of base64 that @solana/web3.js uses
 export async function getAllStakeAccounts(url: string): Promise<PublicKey[]> {
-  console.log('LOG')
   const response = await axios({
     method: 'post',
     url: url,
@@ -29,6 +28,5 @@ export async function getAllStakeAccounts(url: string): Promise<PublicKey[]> {
       ],
     },
   })
-  console.log('LOG2')
   return response.data.result.map((x: any) => new PublicKey(x.pubkey))
 }

--- a/frontend/pages/api/getAllStakingAccounts.ts
+++ b/frontend/pages/api/getAllStakingAccounts.ts
@@ -5,6 +5,7 @@ import axios from 'axios'
 // The JSON payload is too big when using the @solana/web3.js getProgramAccounts
 // We get around this by using the base64+ztsd encoding instead of base64 that @solana/web3.js uses
 export async function getAllStakeAccounts(url: string): Promise<PublicKey[]> {
+  console.log('LOG')
   const response = await axios({
     method: 'post',
     url: url,
@@ -28,5 +29,6 @@ export async function getAllStakeAccounts(url: string): Promise<PublicKey[]> {
       ],
     },
   })
+  console.log('LOG2')
   return response.data.result.map((x: any) => new PublicKey(x.pubkey))
 }

--- a/frontend/pages/api/v1/all_locked_accounts.ts
+++ b/frontend/pages/api/v1/all_locked_accounts.ts
@@ -4,7 +4,6 @@ import BN from 'bn.js'
 import { STAKING_ADDRESS } from '@pythnetwork/staking/app/constants'
 import {
   getAllMetadataAccounts,
-  getAllStakeAccounts,
   getCustodyAccountAddress,
   hasStandardLockup,
 } from '@pythnetwork/staking/app/api_utils'
@@ -15,8 +14,10 @@ import { Staking } from '@pythnetwork/staking/lib/target/types/staking'
 import idl from '@pythnetwork/staking/target/idl/staking.json'
 import { splTokenProgram } from '@coral-xyz/spl-token'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { getAllStakeAccounts } from '../getAllStakingAccounts'
 
-const connection = new Connection(process.env.BACKEND_ENDPOINT!)
+const RPC_URL = process.env.BACKEND_ENDPOINT!
+const connection = new Connection(RPC_URL)
 const provider = new AnchorProvider(
   connection,
   new NodeWallet(new Keypair()),
@@ -36,7 +37,7 @@ export default async function handlerAllLockedAccounts(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const allStakeAccounts = await getAllStakeAccounts(connection)
+  const allStakeAccounts = await getAllStakeAccounts(RPC_URL)
 
   const allMetadataAccounts = await getAllMetadataAccounts(
     stakingProgram,

--- a/frontend/pages/api/v1/all_locked_accounts.ts
+++ b/frontend/pages/api/v1/all_locked_accounts.ts
@@ -2,6 +2,11 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { PythBalance } from '@pythnetwork/staking/app/pythBalance'
 import BN from 'bn.js'
 import { STAKING_ADDRESS } from '@pythnetwork/staking/app/constants'
+import {
+  getCustodyAccountAddress,
+  getMetadataAccountAddress,
+} from '@pythnetwork/staking/app/api_utils'
+
 import { Connection, Keypair, PublicKey } from '@solana/web3.js'
 import { bs58 } from '@coral-xyz/anchor/dist/cjs/utils/bytes'
 import { Program, AnchorProvider, IdlAccounts } from '@coral-xyz/anchor'
@@ -10,10 +15,6 @@ import { Staking } from '@pythnetwork/staking/lib/target/types/staking'
 import idl from '@pythnetwork/staking/target/idl/staking.json'
 import { splTokenProgram } from '@coral-xyz/spl-token'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
-import {
-  getCustodyAccountAddress,
-  getMetadataAccountAddress,
-} from '@pythnetwork/staking'
 
 const ONE_YEAR = new BN(3600 * 24 * 365)
 

--- a/frontend/pages/api/v1/all_locked_accounts.ts
+++ b/frontend/pages/api/v1/all_locked_accounts.ts
@@ -13,7 +13,7 @@ import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import {
   getCustodyAccountAddress,
   getMetadataAccountAddress,
-} from './locked_accounts'
+} from '@pythnetwork/staking'
 
 const ONE_YEAR = new BN(3600 * 24 * 365)
 

--- a/frontend/pages/api/v1/cmc/supply.ts
+++ b/frontend/pages/api/v1/cmc/supply.ts
@@ -2,21 +2,21 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { PythBalance } from '@pythnetwork/staking/app/pythBalance'
 import BN from 'bn.js'
 import { STAKING_ADDRESS } from '@pythnetwork/staking/app/constants'
-import { Connection, Keypair, PublicKey } from '@solana/web3.js'
-import { Program, AnchorProvider, IdlAccounts } from '@coral-xyz/anchor'
+import { Connection, Keypair } from '@solana/web3.js'
+import { Program, AnchorProvider } from '@coral-xyz/anchor'
 import NodeWallet from '@coral-xyz/anchor/dist/cjs/nodewallet'
 import { Staking } from '@pythnetwork/staking/lib/target/types/staking'
 import idl from '@pythnetwork/staking/target/idl/staking.json'
 import { splTokenProgram } from '@coral-xyz/spl-token'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
-import { getConfig } from './../locked_accounts'
 import {
+  getCurrentlyLockedAmount,
+  getTotalSupply,
   getAllCustodyAccounts,
   getAllMetadataAccounts,
+  getConfig,
   getAllStakeAccounts,
-} from '../all_locked_accounts'
-
-const PYTH_TOKEN = new PublicKey('HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3')
+} from '@pythnetwork/staking/app/api_utils'
 
 const connection = new Connection(process.env.BACKEND_ENDPOINT!)
 const provider = new AnchorProvider(
@@ -87,62 +87,4 @@ export default async function handlerSupply(
         "The 'q' query parameter must be one of 'totalSupply' or 'circulatingSupply'.",
     })
   }
-}
-
-function getCurrentlyLockedAmount(
-  metadataAccountData: IdlAccounts<Staking>['stakeAccountMetadataV2'],
-  configAccountData: IdlAccounts<Staking>['globalConfig']
-): PythBalance {
-  const lock = metadataAccountData.lock
-  const listTime = configAccountData.pythTokenListTime
-  if (lock.fullyVested) {
-    return PythBalance.zero()
-  } else if (lock.periodicVestingAfterListing) {
-    if (!listTime) {
-      return new PythBalance(lock.periodicVestingAfterListing.initialBalance)
-    } else {
-      return getCurrentlyLockedAmountPeriodic(
-        listTime,
-        lock.periodicVestingAfterListing.periodDuration,
-        lock.periodicVestingAfterListing.numPeriods,
-        lock.periodicVestingAfterListing.initialBalance
-      )
-    }
-  } else if (lock.periodicVesting) {
-    return getCurrentlyLockedAmountPeriodic(
-      lock.periodicVesting.startDate,
-      lock.periodicVesting.periodDuration,
-      lock.periodicVesting.numPeriods,
-      lock.periodicVesting.initialBalance
-    )
-  } else {
-    throw new Error('Should be unreachable')
-  }
-}
-
-function getCurrentlyLockedAmountPeriodic(
-  startDate: BN,
-  periodDuration: BN,
-  numPeriods: BN,
-  initialBalance: BN
-): PythBalance {
-  const currentTimestamp = new BN(Math.floor(Date.now() / 1000))
-  if (currentTimestamp.lte(startDate)) {
-    return new PythBalance(initialBalance)
-  } else {
-    const periodsElapsed = currentTimestamp.sub(startDate).div(periodDuration)
-    if (periodsElapsed.gte(numPeriods)) {
-      return PythBalance.zero()
-    } else {
-      const remainingPeriods = numPeriods.sub(periodsElapsed)
-      return new PythBalance(
-        remainingPeriods.mul(initialBalance).div(numPeriods)
-      )
-    }
-  }
-}
-
-async function getTotalSupply(tokenProgram: any): Promise<PythBalance> {
-  const pythTokenMintData = await tokenProgram.account.mint.fetch(PYTH_TOKEN)
-  return new PythBalance(pythTokenMintData.supply)
 }

--- a/frontend/pages/api/v1/cmc/supply.ts
+++ b/frontend/pages/api/v1/cmc/supply.ts
@@ -14,7 +14,7 @@ import {
   getTotalSupply,
   getAllMetadataAccounts,
   getConfig,
-  getCustodyAccountAddress,
+  getAllCustodyAccounts,
 } from '@pythnetwork/staking/app/api_utils'
 import { getAllStakeAccounts } from 'pages/api/getAllStakingAccounts'
 
@@ -56,11 +56,9 @@ export default async function handlerSupply(
       allStakeAccounts
     )
 
-    const allCustodyAccountAddresses = allStakeAccounts.map((account) =>
-      getCustodyAccountAddress(account)
-    )
-    const allCustodyAccounts = await tokenProgram.account.account.fetchMultiple(
-      allCustodyAccountAddresses
+    const allCustodyAccounts = await getAllCustodyAccounts(
+      tokenProgram,
+      allStakeAccounts
     )
 
     const configAccountData = await getConfig(stakingProgram)

--- a/frontend/pages/api/v1/cmc/supply.ts
+++ b/frontend/pages/api/v1/cmc/supply.ts
@@ -49,6 +49,7 @@ export default async function handlerSupply(
     res.setHeader('Cache-Control', 'max-age=0, s-maxage=3600')
     res.status(200).send((await getTotalSupply(tokenProgram)).toString(false))
   } else if (q === 'circulatingSupply') {
+    const configAccountData = await getConfig(stakingProgram)
     const allStakeAccounts = await getAllStakeAccounts(RPC_URL)
 
     const allMetadataAccounts = await getAllMetadataAccounts(
@@ -61,13 +62,11 @@ export default async function handlerSupply(
       allStakeAccounts
     )
 
-    const configAccountData = await getConfig(stakingProgram)
-
     const totalLockedAmount = allMetadataAccounts.reduce(
       (total: PythBalance, account: any, index: number) => {
         return total.add(
-          allCustodyAccounts[index]?.amount && account.lock
-            ? new PythBalance(allCustodyAccounts[index]!.amount).min(
+          allCustodyAccounts[index].amount && account.lock
+            ? new PythBalance(allCustodyAccounts[index].amount).min(
                 getCurrentlyLockedAmount(account, configAccountData)
               )
             : PythBalance.zero()

--- a/frontend/pages/api/v1/cmc/supply.ts
+++ b/frontend/pages/api/v1/cmc/supply.ts
@@ -12,7 +12,6 @@ import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import {
   getCurrentlyLockedAmount,
   getTotalSupply,
-  getAllCustodyAccounts,
   getAllMetadataAccounts,
   getConfig,
   getCustodyAccountAddress,

--- a/frontend/pages/api/v1/locked_accounts.ts
+++ b/frontend/pages/api/v1/locked_accounts.ts
@@ -14,6 +14,9 @@ import { StakeConnection } from '@pythnetwork/staking'
 
 export const runtime = 'edge' // 'nodejs' is the default
 export const dynamic = 'force-dynamic' // static by default, unless reading the request
+export const config = {
+  runtime: 'experimental-edge',
+}
 
 const connection = new Connection(process.env.BACKEND_ENDPOINT!)
 const provider = new AnchorProvider(

--- a/frontend/pages/api/v1/locked_accounts.ts
+++ b/frontend/pages/api/v1/locked_accounts.ts
@@ -13,7 +13,7 @@ import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import {
   getCustodyAccountAddress,
   getMetadataAccountAddress,
-} from '@pythnetwork/staking'
+} from '@pythnetwork/staking/app/api_utils'
 
 const connection = new Connection(process.env.BACKEND_ENDPOINT!)
 const provider = new AnchorProvider(

--- a/frontend/pages/api/v1/locked_accounts.ts
+++ b/frontend/pages/api/v1/locked_accounts.ts
@@ -43,6 +43,8 @@ export default async function handlerLockedAccounts(
       connection,
       new PublicKey(owner)
     )
+    await StakeConnection.connect(connection, new NodeWallet(new Keypair()))
+
     const stakeAccountDetails = await Promise.all(
       stakeAccounts.map((account) => {
         return getStakeAccountDetails(account)

--- a/frontend/pages/api/v1/locked_accounts.ts
+++ b/frontend/pages/api/v1/locked_accounts.ts
@@ -10,6 +10,7 @@ import { Staking } from '@pythnetwork/staking/lib/target/types/staking'
 import idl from '@pythnetwork/staking/target/idl/staking.json'
 import { splTokenProgram } from '@coral-xyz/spl-token'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { StakeConnection } from '@pythnetwork/staking'
 
 const connection = new Connection(process.env.BACKEND_ENDPOINT!)
 const provider = new AnchorProvider(

--- a/frontend/pages/api/v1/locked_accounts.ts
+++ b/frontend/pages/api/v1/locked_accounts.ts
@@ -12,6 +12,9 @@ import { splTokenProgram } from '@coral-xyz/spl-token'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import { StakeConnection } from '@pythnetwork/staking'
 
+export const runtime = 'edge' // 'nodejs' is the default
+export const dynamic = 'force-dynamic' // static by default, unless reading the request
+
 const connection = new Connection(process.env.BACKEND_ENDPOINT!)
 const provider = new AnchorProvider(
   connection,

--- a/frontend/pages/api/v1/locked_accounts.ts
+++ b/frontend/pages/api/v1/locked_accounts.ts
@@ -10,13 +10,10 @@ import { Staking } from '@pythnetwork/staking/lib/target/types/staking'
 import idl from '@pythnetwork/staking/target/idl/staking.json'
 import { splTokenProgram } from '@coral-xyz/spl-token'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
-import { StakeConnection } from '@pythnetwork/staking'
-
-export const runtime = 'edge' // 'nodejs' is the default
-export const dynamic = 'force-dynamic' // static by default, unless reading the request
-export const config = {
-  runtime: 'experimental-edge',
-}
+import {
+  getCustodyAccountAddress,
+  getMetadataAccountAddress,
+} from '@pythnetwork/staking'
 
 const connection = new Connection(process.env.BACKEND_ENDPOINT!)
 const provider = new AnchorProvider(
@@ -49,7 +46,6 @@ export default async function handlerLockedAccounts(
       connection,
       new PublicKey(owner)
     )
-    await StakeConnection.connect(connection, new NodeWallet(new Keypair()))
 
     const stakeAccountDetails = await Promise.all(
       stakeAccounts.map((account) => {
@@ -93,20 +89,6 @@ async function getStakeAccountDetails(positionAccountAddress: PublicKey) {
     actualAmount: new PythBalance(custodyAccountData.amount).toString(),
     lock: getLockSummary(lock, configAccountData.pythTokenListTime),
   }
-}
-
-export function getMetadataAccountAddress(positionAccountAddress: PublicKey) {
-  return PublicKey.findProgramAddressSync(
-    [Buffer.from('stake_metadata'), positionAccountAddress.toBuffer()],
-    STAKING_ADDRESS
-  )[0]
-}
-
-export function getCustodyAccountAddress(positionAccountAddress: PublicKey) {
-  return PublicKey.findProgramAddressSync(
-    [Buffer.from('custody'), positionAccountAddress.toBuffer()],
-    STAKING_ADDRESS
-  )[0]
 }
 
 async function getStakeAccounts(connection: Connection, owner: PublicKey) {

--- a/frontend/pages/api/v1/locked_accounts.ts
+++ b/frontend/pages/api/v1/locked_accounts.ts
@@ -9,7 +9,7 @@ import { splTokenProgram } from '@coral-xyz/spl-token'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import {
   getStakeAccountDetails,
-  getStakeAccounts,
+  getStakeAccountsByOwner,
 } from '@pythnetwork/staking/app/api_utils'
 
 const connection = new Connection(process.env.BACKEND_ENDPOINT!)
@@ -39,7 +39,7 @@ export default async function handlerLockedAccounts(
       error: "Must provide the 'owner' query parameters",
     })
   } else {
-    const stakeAccounts = await getStakeAccounts(
+    const stakeAccounts = await getStakeAccountsByOwner(
       connection,
       new PublicKey(owner)
     )

--- a/frontend/pages/api/v1/locked_accounts.ts
+++ b/frontend/pages/api/v1/locked_accounts.ts
@@ -1,18 +1,15 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { PythBalance } from '@pythnetwork/staking/app/pythBalance'
-import BN from 'bn.js'
 import { STAKING_ADDRESS } from '@pythnetwork/staking/app/constants'
 import { Connection, Keypair, PublicKey } from '@solana/web3.js'
-import { bs58 } from '@coral-xyz/anchor/dist/cjs/utils/bytes'
-import { Program, AnchorProvider, IdlAccounts } from '@coral-xyz/anchor'
+import { Program, AnchorProvider } from '@coral-xyz/anchor'
 import NodeWallet from '@coral-xyz/anchor/dist/cjs/nodewallet'
 import { Staking } from '@pythnetwork/staking/lib/target/types/staking'
 import idl from '@pythnetwork/staking/target/idl/staking.json'
 import { splTokenProgram } from '@coral-xyz/spl-token'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import {
-  getCustodyAccountAddress,
-  getMetadataAccountAddress,
+  getStakeAccountDetails,
+  getStakeAccounts,
 } from '@pythnetwork/staking/app/api_utils'
 
 const connection = new Connection(process.env.BACKEND_ENDPOINT!)
@@ -49,114 +46,9 @@ export default async function handlerLockedAccounts(
 
     const stakeAccountDetails = await Promise.all(
       stakeAccounts.map((account) => {
-        return getStakeAccountDetails(account)
+        return getStakeAccountDetails(stakingProgram, tokenProgram, account)
       })
     )
     res.status(200).json(stakeAccountDetails)
   }
-}
-
-export async function getConfig(
-  stakingProgram: Program<Staking>
-): Promise<IdlAccounts<Staking>['globalConfig']> {
-  const configAccountAddress = PublicKey.findProgramAddressSync(
-    [Buffer.from('config')],
-    STAKING_ADDRESS
-  )[0]
-  return await stakingProgram.account.globalConfig.fetch(configAccountAddress)
-}
-
-async function getStakeAccountDetails(positionAccountAddress: PublicKey) {
-  const configAccountData = await getConfig(stakingProgram)
-
-  const metadataAccountAddress = getMetadataAccountAddress(
-    positionAccountAddress
-  )
-  const metadataAccountData =
-    await stakingProgram.account.stakeAccountMetadataV2.fetch(
-      metadataAccountAddress
-    )
-
-  const lock = metadataAccountData.lock
-
-  const custodyAccountAddress = getCustodyAccountAddress(positionAccountAddress)
-  const custodyAccountData = await tokenProgram.account.account.fetch(
-    custodyAccountAddress
-  )
-
-  return {
-    custodyAccount: custodyAccountAddress.toBase58(),
-    actualAmount: new PythBalance(custodyAccountData.amount).toString(),
-    lock: getLockSummary(lock, configAccountData.pythTokenListTime),
-  }
-}
-
-async function getStakeAccounts(connection: Connection, owner: PublicKey) {
-  const response = await connection.getProgramAccounts(STAKING_ADDRESS, {
-    encoding: 'base64',
-    filters: [
-      {
-        memcmp: {
-          offset: 0,
-          bytes: bs58.encode(Buffer.from('55c3f14f7cc04f0b', 'hex')), // Positions account discriminator
-        },
-      },
-      {
-        memcmp: {
-          offset: 8,
-          bytes: owner.toBase58(),
-        },
-      },
-    ],
-  })
-  return response.map((account) => {
-    return account.pubkey
-  })
-}
-
-export function getLockSummary(lock: any, listTime: BN | null) {
-  if (lock.fullyVested) {
-    return { type: 'fullyUnlocked' }
-  } else if (lock.periodicVestingAfterListing) {
-    return {
-      type: 'periodicUnlockingAfterListing',
-      schedule: getUnlockEvents(
-        listTime,
-        lock.periodicVestingAfterListing.periodDuration,
-        lock.periodicVestingAfterListing.numPeriods,
-        lock.periodicVestingAfterListing.initialBalance
-      ),
-    }
-  } else if (lock.periodicVesting) {
-    return {
-      type: 'periodicUnlocking',
-      schedule: getUnlockEvents(
-        lock.periodicVesting.startDate,
-        lock.periodicVesting.periodDuration,
-        lock.periodicVesting.numPeriods,
-        lock.periodicVesting.initialBalance
-      ),
-    }
-  }
-}
-
-export function getUnlockEvents(
-  startData: BN | null,
-  periodDuration: BN,
-  numberOfPeriods: BN,
-  initialBalance: BN
-) {
-  if (startData) {
-    return Array(numberOfPeriods.toNumber())
-      .fill(0)
-      .map((_, i) => {
-        return {
-          date: startData.add(periodDuration.muln(i + 1)).toString(),
-          amount: new PythBalance(
-            initialBalance.divn(numberOfPeriods.toNumber())
-          ).toString(),
-        }
-      })
-  }
-  return []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@solana/wallet-adapter-wallets": "^0.19.16",
         "@solana/web3.js": "^1.87.5",
         "@tippyjs/react": "^4.2.6",
+        "axios": "^1.6.7",
         "dotenv": "^16.0.0",
         "next": "12.2.5",
         "prop-types": "^15.8.1",
@@ -9765,11 +9766,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -12902,9 +12903,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -31408,11 +31409,11 @@
       "from": "avsc@https://github.com/Irys-xyz/avsc#csp-fixes"
     },
     "axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -33862,9 +33863,9 @@
       "peer": true
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -38727,6 +38728,7 @@
         "@types/node": "20.3.1",
         "@types/react": "^18.0.1",
         "autoprefixer": "^10.4.0",
+        "axios": "^1.6.7",
         "dotenv": "^16.0.0",
         "next": "12.2.5",
         "postcss": "^8.4.5",

--- a/staking/app/api_utils.ts
+++ b/staking/app/api_utils.ts
@@ -120,16 +120,6 @@ export async function getAllMetadataAccounts(
   );
 }
 
-export async function getAllCustodyAccounts(
-  tokenProgram: any,
-  stakeAccounts: PublicKey[]
-) {
-  const allCustodyAccountAddresses = stakeAccounts.map((account) =>
-    getCustodyAccountAddress(account)
-  );
-  return tokenProgram.account.account.fetchMultiple(allCustodyAccountAddresses);
-}
-
 // ======================================
 // Locked accounts
 // ======================================

--- a/staking/app/api_utils.ts
+++ b/staking/app/api_utils.ts
@@ -1,7 +1,14 @@
 // This file contains utility functions for the API. We can't use StakeConnection directly because it has wasm imports that are not compatible with the Next API.
 
-import { PublicKey } from "@solana/web3.js";
-import { STAKING_ADDRESS } from "./constants";
+import { Connection, PublicKey } from "@solana/web3.js";
+import { STAKING_ADDRESS, PYTH_TOKEN } from "./constants";
+import BN from "bn.js";
+import { PythBalance } from "./pythBalance";
+import { IdlAccounts, Program } from "@coral-xyz/anchor";
+import { Staking } from "../target/types/staking";
+import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
+
+const ONE_YEAR = new BN(3600 * 24 * 365);
 
 export function getMetadataAccountAddress(positionAccountAddress: PublicKey) {
   return PublicKey.findProgramAddressSync(
@@ -15,4 +22,233 @@ export function getCustodyAccountAddress(positionAccountAddress: PublicKey) {
     [Buffer.from("custody"), positionAccountAddress.toBuffer()],
     STAKING_ADDRESS
   )[0];
+}
+
+export async function getConfig(
+  stakingProgram: Program<Staking>
+): Promise<IdlAccounts<Staking>["globalConfig"]> {
+  const configAccountAddress = PublicKey.findProgramAddressSync(
+    [Buffer.from("config")],
+    STAKING_ADDRESS
+  )[0];
+  return await stakingProgram.account.globalConfig.fetch(configAccountAddress);
+}
+
+export async function getTotalSupply(tokenProgram: any): Promise<PythBalance> {
+  const pythTokenMintData = await tokenProgram.account.mint.fetch(PYTH_TOKEN);
+  return new PythBalance(pythTokenMintData.supply);
+}
+
+export async function getAllStakeAccounts(connection: Connection) {
+  const response = await connection.getProgramAccounts(STAKING_ADDRESS, {
+    encoding: "base64",
+    filters: [
+      {
+        memcmp: {
+          offset: 0,
+          bytes: bs58.encode(Buffer.from("55c3f14f7cc04f0b", "hex")), // Positions account discriminator
+        },
+      },
+    ],
+  });
+  return response.map((account) => {
+    return account.pubkey;
+  });
+}
+
+export async function getAllMetadataAccounts(
+  stakingProgram: Program<Staking>,
+  stakeAccounts: PublicKey[]
+): Promise<(IdlAccounts<Staking>["stakeAccountMetadataV2"] | null)[]> {
+  const metadataAccountAddresses = stakeAccounts.map((account) =>
+    getMetadataAccountAddress(account)
+  );
+  return stakingProgram.account.stakeAccountMetadataV2.fetchMultiple(
+    metadataAccountAddresses
+  );
+}
+
+export async function getAllCustodyAccounts(
+  tokenProgram: any,
+  stakeAccounts: PublicKey[]
+) {
+  const allCustodyAccountAddresses = stakeAccounts.map((account) =>
+    getCustodyAccountAddress(account)
+  );
+  return tokenProgram.account.account.fetchMultiple(allCustodyAccountAddresses);
+}
+
+export function hasStandardLockup(
+  metadataAccountData: IdlAccounts<Staking>["stakeAccountMetadataV2"]
+) {
+  return (
+    metadataAccountData.lock.periodicVestingAfterListing &&
+    metadataAccountData.lock.periodicVestingAfterListing.numPeriods.eq(
+      new BN(4)
+    ) &&
+    metadataAccountData.lock.periodicVestingAfterListing.periodDuration.eq(
+      ONE_YEAR
+    )
+  );
+}
+
+export async function getStakeAccountDetails(
+  stakingProgram: Program<Staking>,
+  tokenProgram: any,
+  positionAccountAddress: PublicKey
+) {
+  const configAccountData = await getConfig(stakingProgram);
+
+  const metadataAccountAddress = getMetadataAccountAddress(
+    positionAccountAddress
+  );
+  const metadataAccountData =
+    await stakingProgram.account.stakeAccountMetadataV2.fetch(
+      metadataAccountAddress
+    );
+
+  const lock = metadataAccountData.lock;
+
+  const custodyAccountAddress = getCustodyAccountAddress(
+    positionAccountAddress
+  );
+  const custodyAccountData = await tokenProgram.account.account.fetch(
+    custodyAccountAddress
+  );
+
+  return {
+    custodyAccount: custodyAccountAddress.toBase58(),
+    actualAmount: new PythBalance(custodyAccountData.amount).toString(),
+    lock: getLockSummary(lock, configAccountData.pythTokenListTime),
+  };
+}
+
+export async function getStakeAccounts(
+  connection: Connection,
+  owner: PublicKey
+) {
+  const response = await connection.getProgramAccounts(STAKING_ADDRESS, {
+    encoding: "base64",
+    filters: [
+      {
+        memcmp: {
+          offset: 0,
+          bytes: bs58.encode(Buffer.from("55c3f14f7cc04f0b", "hex")), // Positions account discriminator
+        },
+      },
+      {
+        memcmp: {
+          offset: 8,
+          bytes: owner.toBase58(),
+        },
+      },
+    ],
+  });
+  return response.map((account) => {
+    return account.pubkey;
+  });
+}
+
+// ======================================
+// Locked accounts
+// ======================================
+
+export function getCurrentlyLockedAmount(
+  metadataAccountData: IdlAccounts<Staking>["stakeAccountMetadataV2"],
+  configAccountData: IdlAccounts<Staking>["globalConfig"]
+): PythBalance {
+  const lock = metadataAccountData.lock;
+  const listTime = configAccountData.pythTokenListTime;
+  if (lock.fullyVested) {
+    return PythBalance.zero();
+  } else if (lock.periodicVestingAfterListing) {
+    if (!listTime) {
+      return new PythBalance(lock.periodicVestingAfterListing.initialBalance);
+    } else {
+      return getCurrentlyLockedAmountPeriodic(
+        listTime,
+        lock.periodicVestingAfterListing.periodDuration,
+        lock.periodicVestingAfterListing.numPeriods,
+        lock.periodicVestingAfterListing.initialBalance
+      );
+    }
+  } else if (lock.periodicVesting) {
+    return getCurrentlyLockedAmountPeriodic(
+      lock.periodicVesting.startDate,
+      lock.periodicVesting.periodDuration,
+      lock.periodicVesting.numPeriods,
+      lock.periodicVesting.initialBalance
+    );
+  } else {
+    throw new Error("Should be unreachable");
+  }
+}
+
+function getCurrentlyLockedAmountPeriodic(
+  startDate: BN,
+  periodDuration: BN,
+  numPeriods: BN,
+  initialBalance: BN
+): PythBalance {
+  const currentTimestamp = new BN(Math.floor(Date.now() / 1000));
+  if (currentTimestamp.lte(startDate)) {
+    return new PythBalance(initialBalance);
+  } else {
+    const periodsElapsed = currentTimestamp.sub(startDate).div(periodDuration);
+    if (periodsElapsed.gte(numPeriods)) {
+      return PythBalance.zero();
+    } else {
+      const remainingPeriods = numPeriods.sub(periodsElapsed);
+      return new PythBalance(
+        remainingPeriods.mul(initialBalance).div(numPeriods)
+      );
+    }
+  }
+}
+
+export function getLockSummary(lock: any, listTime: BN | null) {
+  if (lock.fullyVested) {
+    return { type: "fullyUnlocked" };
+  } else if (lock.periodicVestingAfterListing) {
+    return {
+      type: "periodicUnlockingAfterListing",
+      schedule: getUnlockEvents(
+        listTime,
+        lock.periodicVestingAfterListing.periodDuration,
+        lock.periodicVestingAfterListing.numPeriods,
+        lock.periodicVestingAfterListing.initialBalance
+      ),
+    };
+  } else if (lock.periodicVesting) {
+    return {
+      type: "periodicUnlocking",
+      schedule: getUnlockEvents(
+        lock.periodicVesting.startDate,
+        lock.periodicVesting.periodDuration,
+        lock.periodicVesting.numPeriods,
+        lock.periodicVesting.initialBalance
+      ),
+    };
+  }
+}
+
+function getUnlockEvents(
+  startData: BN | null,
+  periodDuration: BN,
+  numberOfPeriods: BN,
+  initialBalance: BN
+) {
+  if (startData) {
+    return Array(numberOfPeriods.toNumber())
+      .fill(0)
+      .map((_, i) => {
+        return {
+          date: startData.add(periodDuration.muln(i + 1)).toString(),
+          amount: new PythBalance(
+            initialBalance.divn(numberOfPeriods.toNumber())
+          ).toString(),
+        };
+      });
+  }
+  return [];
 }

--- a/staking/app/api_utils.ts
+++ b/staking/app/api_utils.ts
@@ -120,6 +120,16 @@ export async function getAllMetadataAccounts(
   );
 }
 
+export async function getAllCustodyAccounts(
+  tokenProgram: any,
+  stakeAccounts: PublicKey[]
+) {
+  const allCustodyAccountAddresses = stakeAccounts.map((account) =>
+    getCustodyAccountAddress(account)
+  );
+  return tokenProgram.account.account.fetchMultiple(allCustodyAccountAddresses);
+}
+
 // ======================================
 // Locked accounts
 // ======================================

--- a/staking/app/api_utils.ts
+++ b/staking/app/api_utils.ts
@@ -108,23 +108,6 @@ export async function getTotalSupply(tokenProgram: any): Promise<PythBalance> {
   return new PythBalance(pythTokenMintData.supply);
 }
 
-export async function getAllStakeAccounts(connection: Connection) {
-  const response = await connection.getProgramAccounts(STAKING_ADDRESS, {
-    encoding: "base64",
-    filters: [
-      {
-        memcmp: {
-          offset: 0,
-          bytes: bs58.encode(Buffer.from("55c3f14f7cc04f0b", "hex")), // Positions account discriminator
-        },
-      },
-    ],
-  });
-  return response.map((account) => {
-    return account.pubkey;
-  });
-}
-
 export async function getAllMetadataAccounts(
   stakingProgram: Program<Staking>,
   stakeAccounts: PublicKey[]

--- a/staking/app/api_utils.ts
+++ b/staking/app/api_utils.ts
@@ -1,0 +1,18 @@
+// This file contains utility functions for the API. We can't use StakeConnection directly because it has wasm imports that are not compatible with the Next API.
+
+import { PublicKey } from "@solana/web3.js";
+import { STAKING_ADDRESS } from "./constants";
+
+export function getMetadataAccountAddress(positionAccountAddress: PublicKey) {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("stake_metadata"), positionAccountAddress.toBuffer()],
+    STAKING_ADDRESS
+  )[0];
+}
+
+export function getCustodyAccountAddress(positionAccountAddress: PublicKey) {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("custody"), positionAccountAddress.toBuffer()],
+    STAKING_ADDRESS
+  )[0];
+}

--- a/staking/app/api_utils.ts
+++ b/staking/app/api_utils.ts
@@ -1,4 +1,4 @@
-// This file contains utility functions for the API. We can't use StakeConnection directly because it has wasm imports that are not compatible with the Next API.
+// This file contains utility functions for the API. Unfortunately we can't use StakeConnection directly because it has wasm imports that are not compatible with the Next API.
 
 import { Connection, PublicKey } from "@solana/web3.js";
 import { STAKING_ADDRESS, PYTH_TOKEN } from "./constants";

--- a/staking/app/constants.ts
+++ b/staking/app/constants.ts
@@ -20,4 +20,9 @@ export const REALM_ID = new PublicKey(
   "4ct8XU5tKbMNRphWy4rePsS9kBqPhDdvZoGpmprPaug4"
 );
 
+// This one is valid on mainnet only
+export const PYTH_TOKEN = new PublicKey(
+  "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3"
+);
+
 export const EPOCH_DURATION = 3600 * 24 * 7;

--- a/staking/app/index.ts
+++ b/staking/app/index.ts
@@ -6,4 +6,5 @@ export {
   VestingAccountState,
 } from "./StakeConnection";
 export * from "./constants";
+export * from "./api_utils";
 export { PYTH_DECIMALS, PythBalance } from "./pythBalance";

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,10 @@
 {
   "functions": {
     "pages/api/v1/all_locked_accounts.ts": {
-      "maxDuration": 90
+      "maxDuration": 30
     },
     "pages/api/v1/cmc/supply.ts": {
-      "maxDuration": 90
+      "maxDuration": 30
     }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,10 @@
 {
   "functions": {
     "pages/api/v1/all_locked_accounts.ts": {
-      "maxDuration": 60
+      "maxDuration": 90
     },
     "pages/api/v1/cmc/supply.ts": {
-      "maxDuration": 60
+      "maxDuration": 90
     }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,10 @@
 {
   "functions": {
     "pages/api/v1/all_locked_accounts.ts": {
-      "maxDuration": 30
+      "maxDuration": 60
     },
     "pages/api/v1/cmc/supply.ts": {
-      "maxDuration": 30
-    },
-    "pages/api/internal/create_ephemeral_account.ts": {
-      "maxDuration": 30
+      "maxDuration": 60
     }
   }
 }


### PR DESCRIPTION
The large volume of new stake accounts has broken the API for the total number of locked tokens.
The goals of this PR are :
- refactor a bunch of functions used in the APIs into `api_utils.ts`
- create a new implementation of `getAllStakeAccounts` that is more efficient

It still don't works but I think it's in a reviewable state