### PR TITLE
feat: cleanup position before split request

### DIFF
--- a/staking/app/StakeConnection.ts
+++ b/staking/app/StakeConnection.ts
@@ -921,6 +921,11 @@ export class StakeConnection {
       ComputeBudgetProgram.setComputeUnitLimit({ units: 30000 }),
       ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 30101 }),
     ];
+
+    preInstructions.push(
+      ...(await this.buildCleanupUnlockedPositions(stakeAccount))
+    );
+
     await this.program.methods
       .requestSplit(amount.toBN(), recipient)
       .preInstructions(preInstructions)


### PR DESCRIPTION
Some users that are unstaked can't request splits because they have deactivated positions. This is meant to fix it.