### PR TITLE
fix: remove compute cap

### DIFF
--- a/staking/app/StakeConnection.ts
+++ b/staking/app/StakeConnection.ts
@@ -918,8 +918,7 @@ export class StakeConnection {
     recipient: PublicKey
   ) {
     const preInstructions = [
-      ComputeBudgetProgram.setComputeUnitLimit({ units: 30000 }),
-      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 30101 }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1000 }),
     ];
 
     preInstructions.push(


### PR DESCRIPTION
With the step that cleans up positions the compute cap sometimes gets exceeded.
I'm reducing the compute unit price so that the cost remains similar.