### PR TITLE
fix: use the correct error in the recover account

### DIFF
--- a/staking/programs/staking/src/lib.rs
+++ b/staking/programs/staking/src/lib.rs
@@ -718,7 +718,7 @@ pub mod staking {
         // Transferring accounts with staked tokens might lead to double voting
         require!(
             ctx.accounts.stake_account_metadata.next_index == 0,
-            ErrorCode::SplitWithStake
+            ErrorCode::RecoverWithStake
         );
 
         let new_owner = ctx.accounts.payer_token_account.owner;


### PR DESCRIPTION
The SplitWithStake error message for accounts with staked tokens has been replaced with RecoverWithStake. This change is reflected in the lib.rs file under the recover account function. This implementation guards against the possibility of double voting that could occur if an account with staked tokens were allowed to be transferred.