### PR TITLE
feat: add verifiable staking build script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24001,7 +24001,7 @@
     },
     "staking": {
       "name": "@pythnetwork/staking",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@coral-xyz/anchor": "^0.29.0",

--- a/staking/.dockerignore
+++ b/staking/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/staking/.gitignore
+++ b/staking/.gitignore
@@ -7,3 +7,4 @@ node_modules
 lib
 .env
 snapshots
+/artifacts

--- a/staking/Dockerfile
+++ b/staking/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Docker image to generate a deterministic build of the Pyth Staking Program
-# program. This image extends backpackapp/build to support local dependencies
-# outside the Cargo workspace of the program.
+# program. This image extends projectserum/build which is based on backpackapp/build
+# but with a specific version of the Solana CLI and Anchor CLI.
 #
 
 FROM projectserum/build:v0.27.0@sha256:0e11aced57c448c7da9bf0a563a146398ac8b88f357b8fc2e1be314b42320686

--- a/staking/Dockerfile
+++ b/staking/Dockerfile
@@ -1,0 +1,14 @@
+#
+# Docker image to generate a deterministic build of the Pyth Staking Program
+# program. This image extends backpackapp/build to support local dependencies
+# outside the Cargo workspace of the program.
+#
+
+FROM backpackapp/build:v0.29.0@sha256:9aee169b2d8b89b4a4243419ae35c176773136e78d751b3e439eff692c9c1293
+
+WORKDIR /workspace
+
+COPY . .
+
+CMD ["bash", "-c", \
+        "anchor build --arch sbf && cp target/deploy/staking.so /artifacts/staking.so"]

--- a/staking/Dockerfile
+++ b/staking/Dockerfile
@@ -4,11 +4,11 @@
 # outside the Cargo workspace of the program.
 #
 
-FROM backpackapp/build:v0.29.0@sha256:9aee169b2d8b89b4a4243419ae35c176773136e78d751b3e439eff692c9c1293
+FROM projectserum/build:v0.27.0@sha256:0e11aced57c448c7da9bf0a563a146398ac8b88f357b8fc2e1be314b42320686
 
 WORKDIR /workspace
 
 COPY . .
 
 CMD ["bash", "-c", \
-        "anchor build --arch sbf && cp target/deploy/staking.so /artifacts/staking.so"]
+        "anchor build && cp target/deploy/staking.so /artifacts/staking.so"]

--- a/staking/scripts/build_verifiable_staking_program.sh
+++ b/staking/scripts/build_verifiable_staking_program.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Root of the repository
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+echo "Building the image for the staking program"
+docker build --platform linux/x86_64 -t staking-build -f "$REPO_ROOT"/staking/Dockerfile "$REPO_ROOT"/staking
+
+echo "Building the staking program"
+docker run --platform linux/x86_64 --rm -v "$REPO_ROOT"/staking/artifacts:/artifacts staking-build
+
+echo "Successfully built the staking program."
+echo "The artifacts are available at $REPO_ROOT/staking/artifacts"
+
+CHECKSUM=$(sha256sum $REPO_ROOT/staking/artifacts/staking.so | awk '{print $1}')
+echo "sha256sum of the staking program: $CHECKSUM"


### PR DESCRIPTION
This change adds a Dockerfile based on Anchor's default verifiable build dockerfile and a script to build the program using that Dockerfile. The script also prints the sha256sum of the program which can be used to verify on-chain deployments.