### PR TITLE
Make sure the staking package is built before checking types

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -59,6 +59,9 @@ jobs:
       - name: Install node packages
         run: npm ci
 
+      - name: Build staking package
+        run: npm run -w staking build
+
       - name: Check typescript types
         run: npm run -w frontend test:types
 
@@ -76,6 +79,9 @@ jobs:
 
       - name: Install node packages
         run: nix-shell --run "cli install"
+
+      - name: Build staking package
+        run: nix-shell --run "npm run -w staking build"
 
       - name: Test
         run: nix-shell --run "cli test"


### PR DESCRIPTION
When I set up #442 , I didn't take into account that the staking package must be built before running type checks.

This PR fixes that so that the CI type checks work correctly.