### PR TITLE
feat: add priority fees

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,3 @@ staking/lib
 wasm
 staking/app/keypairs
 docs/
-frontend/

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ staking/lib
 wasm
 staking/app/keypairs
 docs/
+frontend/

--- a/frontend/hooks/useStakeConnection.ts
+++ b/frontend/hooks/useStakeConnection.ts
@@ -21,7 +21,8 @@ export function useStakeConnection() {
         STAKING_ADDRESS,
         process.env.ADDRESS_LOOKUP_TABLE
           ? new PublicKey(process.env.ADDRESS_LOOKUP_TABLE)
-          : undefined
+          : undefined,
+        {computeUnitPriceMicroLamports:0}
       )
     },
     {

--- a/frontend/hooks/useStakeConnection.ts
+++ b/frontend/hooks/useStakeConnection.ts
@@ -22,7 +22,7 @@ export function useStakeConnection() {
         process.env.ADDRESS_LOOKUP_TABLE
           ? new PublicKey(process.env.ADDRESS_LOOKUP_TABLE)
           : undefined,
-        {computeUnitPriceMicroLamports:50000}
+        { computeUnitPriceMicroLamports: 50000 }
       )
     },
     {

--- a/frontend/hooks/useStakeConnection.ts
+++ b/frontend/hooks/useStakeConnection.ts
@@ -22,7 +22,7 @@ export function useStakeConnection() {
         process.env.ADDRESS_LOOKUP_TABLE
           ? new PublicKey(process.env.ADDRESS_LOOKUP_TABLE)
           : undefined,
-        {computeUnitPriceMicroLamports:0}
+        {computeUnitPriceMicroLamports:50000}
       )
     },
     {

--- a/frontend/pages/test.tsx
+++ b/frontend/pages/test.tsx
@@ -44,15 +44,15 @@ const Test: NextPage = () => {
       <PanelLayout>
         {stakeConnection ? (
           <p>
-            {!hasTested ? (
+            {hasTested ? (
+              <Description>
+                Your wallet has already been tested succesfully.
+              </Description>
+            ) : (
               <Description>
                 Please click the button below and accept the transaction in your
                 wallet to test the browser wallet compatibility. You will need
                 0.001 SOL.
-              </Description>
-            ) : (
-              <Description>
-                Your wallet has already been tested succesfully.
               </Description>
             )}
             <button

--- a/frontend/pages/test.tsx
+++ b/frontend/pages/test.tsx
@@ -44,15 +44,17 @@ const Test: NextPage = () => {
       <PanelLayout>
         {stakeConnection ? (
           <p>
-            { !hasTested ? (
-            <Description>
-              Please click the button below and accept the transaction in your
-              wallet to test the browser wallet compatibility. You will need
-              0.001 SOL.
-            </Description> )
-            : <Description>
-              Your wallet has already been tested succesfully.
-              </Description> }
+            {!hasTested ? (
+              <Description>
+                Please click the button below and accept the transaction in your
+                wallet to test the browser wallet compatibility. You will need
+                0.001 SOL.
+              </Description>
+            ) : (
+              <Description>
+                Your wallet has already been tested succesfully.
+              </Description>
+            )}
             <button
               className="action-btn text-base"
               onClick={() => testWallet()}

--- a/frontend/pages/test.tsx
+++ b/frontend/pages/test.tsx
@@ -42,13 +42,17 @@ const Test: NextPage = () => {
       <SEO title={'Wallet Compatiblity Test'} />
 
       <PanelLayout>
-        {stakeConnection && !hasTested ? (
+        {stakeConnection ? (
           <p>
+            { !hasTested ? (
             <Description>
               Please click the button below and accept the transaction in your
               wallet to test the browser wallet compatibility. You will need
               0.001 SOL.
-            </Description>
+            </Description> )
+            : <Description>
+              Your wallet has already been tested succesfully.
+              </Description> }
             <button
               className="action-btn text-base"
               onClick={() => testWallet()}
@@ -56,10 +60,6 @@ const Test: NextPage = () => {
               Click to test
             </button>
           </p>
-        ) : stakeConnection && hasTested ? (
-          <Description>
-            Your wallet has already been tested succesfully.
-          </Description>
         ) : (
           <p className="p-2 hover:bg-hoverGray"> Please connect your wallet</p>
         )}


### PR DESCRIPTION
I want to add priority fees.
Browser wallets (Phantom) normally add priority fees to transactions created by the frontend.
This is not the case however for WalletConnect integrations like many custody providers.
Therefore I want to turn on a small priority fee so WalletConnect integrations can interact better with this frontend.
