### PR TITLE
feat: make slash events separated for publishers

### DIFF
--- a/staking/programs/integrity-pool/src/context.rs
+++ b/staking/programs/integrity-pool/src/context.rs
@@ -233,11 +233,15 @@ pub struct CreateSlashEvent<'info> {
     )]
     pub slash_custody: Account<'info, TokenAccount>,
 
+    #[account(mut)]
+    pub pool_data: AccountLoader<'info, PoolData>,
+
     #[account(
         mut,
         seeds = [POOL_CONFIG.as_bytes()],
         bump,
-        has_one = reward_program_authority @ IntegrityPoolError::InvalidRewardProgramAuthority
+        has_one = reward_program_authority @ IntegrityPoolError::InvalidRewardProgramAuthority,
+        has_one = pool_data @ IntegrityPoolError::InvalidPoolDataAccount,
     )]
     pub pool_config: Account<'info, PoolConfig>,
 
@@ -245,7 +249,7 @@ pub struct CreateSlashEvent<'info> {
         init,
         payer = payer,
         space = SlashEvent::LEN,
-        seeds = [SLASH_EVENT.as_bytes(), &index.to_be_bytes()],
+        seeds = [SLASH_EVENT.as_bytes(), publisher.key().as_ref(), &index.to_be_bytes()],
         bump,
     )]
     pub slash_event: Account<'info, SlashEvent>,

--- a/staking/programs/integrity-pool/src/error.rs
+++ b/staking/programs/integrity-pool/src/error.rs
@@ -22,4 +22,5 @@ pub enum IntegrityPoolError {
     #[msg("Slash event indexes must be sequential and start at 0")]
     InvalidSlashEventIndex,
     InvalidRewardProgramAuthority,
+    InvalidPoolDataAccount,
 }

--- a/staking/programs/integrity-pool/src/state/pool.rs
+++ b/staking/programs/integrity-pool/src/state/pool.rs
@@ -71,6 +71,7 @@ pub struct PoolData {
     pub publisher_stake_accounts: [Pubkey; MAX_PUBLISHERS],
     pub events:                   [Event; MAX_EVENTS],
     pub num_events:               u64,
+    pub num_slash_events:         [u64; MAX_PUBLISHERS],
 }
 
 impl PoolData {
@@ -391,7 +392,6 @@ pub struct PoolConfig {
     pub reward_program_authority: Pubkey,
     pub pyth_token_mint:          Pubkey,
     pub y:                        frac64,
-    pub num_slash_events:         u64,
 }
 
 impl PoolConfig {
@@ -433,6 +433,7 @@ mod tests {
             publisher_stake_accounts: [Pubkey::default(); MAX_PUBLISHERS],
             events:                   [Event::default(); MAX_EVENTS],
             num_events:               0,
+            num_slash_events:         [0; MAX_PUBLISHERS],
         };
 
         pool_data.get_event_mut(1).epoch = 123;
@@ -451,6 +452,7 @@ mod tests {
             publisher_stake_accounts: [Pubkey::default(); MAX_PUBLISHERS],
             events:                   [Event::default(); MAX_EVENTS],
             num_events:               0,
+            num_slash_events:         [0; MAX_PUBLISHERS],
         };
 
         let event = Event {
@@ -499,6 +501,7 @@ mod tests {
             publisher_stake_accounts: [Pubkey::default(); MAX_PUBLISHERS],
             events:                   [Event::default(); MAX_EVENTS],
             num_events:               0,
+            num_slash_events:         [0; MAX_PUBLISHERS],
         };
 
         let publisher_key = Pubkey::new_unique();
@@ -661,6 +664,7 @@ mod tests {
             publisher_stake_accounts: [Pubkey::default(); MAX_PUBLISHERS],
             events:                   [Event::default(); MAX_EVENTS],
             num_events:               0,
+            num_slash_events:         [0; MAX_PUBLISHERS],
         };
 
         let mut caps = [PublisherCap {
@@ -702,6 +706,7 @@ mod tests {
             publisher_stake_accounts: [Pubkey::default(); MAX_PUBLISHERS],
             events:                   [Event::default(); MAX_EVENTS],
             num_events:               0,
+            num_slash_events:         [0; MAX_PUBLISHERS],
         };
 
         let mut caps = [PublisherCap {

--- a/staking/programs/integrity-pool/tests/integrity_pool_slash.rs
+++ b/staking/programs/integrity-pool/tests/integrity_pool_slash.rs
@@ -53,7 +53,7 @@ fn test_create_slash_event() {
     });
 
     let slash_custody = create_token_account(&mut svm, &payer, &pyth_token_mint.pubkey()).pubkey();
-    let slash_publisher = publisher_keypair.pubkey();
+    let slashed_publisher = publisher_keypair.pubkey();
 
     assert_anchor_program_error(
         create_slash_event(
@@ -63,7 +63,7 @@ fn test_create_slash_event() {
             1,
             FRAC_64_MULTIPLIER / 2,
             slash_custody,
-            slash_publisher,
+            slashed_publisher,
             pool_data_pubkey,
         ),
         IntegrityPoolError::InvalidSlashEventIndex.into(),
@@ -77,7 +77,7 @@ fn test_create_slash_event() {
         0,
         FRAC_64_MULTIPLIER / 2,
         slash_custody,
-        slash_publisher,
+        slashed_publisher,
         pool_data_pubkey,
     )
     .unwrap();
@@ -92,7 +92,7 @@ fn test_create_slash_event() {
         1,
         FRAC_64_MULTIPLIER / 10,
         slash_custody,
-        slash_publisher,
+        slashed_publisher,
         pool_data_pubkey,
     )
     .unwrap();
@@ -109,7 +109,7 @@ fn test_create_slash_event() {
         2,
         FRAC_64_MULTIPLIER / 10,
         slash_custody,
-        slash_publisher,
+        slashed_publisher,
         pool_data_pubkey,
     )
     .unwrap();
@@ -126,7 +126,7 @@ fn test_create_slash_event() {
             4,
             FRAC_64_MULTIPLIER / 2,
             slash_custody,
-            slash_publisher,
+            slashed_publisher,
             pool_data_pubkey,
         ),
         IntegrityPoolError::InvalidSlashEventIndex.into(),
@@ -140,7 +140,7 @@ fn test_create_slash_event() {
             2,
             FRAC_64_MULTIPLIER / 2,
             slash_custody,
-            slash_publisher,
+            slashed_publisher,
             pool_data_pubkey,
         ),
         ProgramError::Custom(0).into(),
@@ -156,7 +156,7 @@ fn test_create_slash_event() {
             3,
             FRAC_64_MULTIPLIER / 2,
             slash_custody,
-            slash_publisher,
+            slashed_publisher,
             pool_data_pubkey,
         ),
         IntegrityPoolError::InvalidRewardProgramAuthority.into(),
@@ -165,26 +165,26 @@ fn test_create_slash_event() {
 
     const STARTING_EPOCH: u64 = 2;
     let slash_account_0: SlashEvent =
-        fetch_account_data(&mut svm, &get_slash_event_address(0, slash_publisher).0);
+        fetch_account_data(&mut svm, &get_slash_event_address(0, slashed_publisher).0);
 
     assert_eq!(slash_account_0.epoch, STARTING_EPOCH);
     assert_eq!(slash_account_0.slash_ratio, FRAC_64_MULTIPLIER / 2);
     assert_eq!(slash_account_0.slash_custody, slash_custody);
-    assert_eq!(slash_account_0.publisher, slash_publisher);
+    assert_eq!(slash_account_0.publisher, slashed_publisher);
 
     let slash_account_1: SlashEvent =
-        fetch_account_data(&mut svm, &get_slash_event_address(1, slash_publisher).0);
+        fetch_account_data(&mut svm, &get_slash_event_address(1, slashed_publisher).0);
 
     assert_eq!(slash_account_1.epoch, STARTING_EPOCH);
     assert_eq!(slash_account_1.slash_ratio, FRAC_64_MULTIPLIER / 10);
     assert_eq!(slash_account_1.slash_custody, slash_custody);
-    assert_eq!(slash_account_1.publisher, slash_publisher);
+    assert_eq!(slash_account_1.publisher, slashed_publisher);
 
     let slash_account_2: SlashEvent =
-        fetch_account_data(&mut svm, &get_slash_event_address(2, slash_publisher).0);
+        fetch_account_data(&mut svm, &get_slash_event_address(2, slashed_publisher).0);
 
     assert_eq!(slash_account_2.epoch, STARTING_EPOCH + 10);
     assert_eq!(slash_account_2.slash_ratio, FRAC_64_MULTIPLIER / 10);
     assert_eq!(slash_account_2.slash_custody, slash_custody);
-    assert_eq!(slash_account_2.publisher, slash_publisher);
+    assert_eq!(slash_account_2.publisher, slashed_publisher);
 }


### PR DESCRIPTION
This pr makes the calculation of the slash events to be on a per publisher basis. The indexes, seeds, and num counters are stored separately per publisher now.