### PR TITLE
feat: add stability test

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,32 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer"
   },
   "rust-analyzer.check.command": "clippy",
-  "rust-analyzer.rustfmt.overrideCommand": ["rustfmt", "+nightly"]
+  "rust-analyzer.rustfmt.overrideCommand": ["rustfmt", "+nightly"],
+  "cSpell.words": [
+    "accs",
+    "blockhash",
+    "borsh",
+    "bytemuck",
+    "delegators",
+    "Keypair",
+    "keypairs",
+    "lamports",
+    "litesvm",
+    "Merkle",
+    "Metas",
+    "PREUNLOCKING",
+    "Pubkey",
+    "pubkeys",
+    "pyth",
+    "pythnet",
+    "quickcheck",
+    "snapshotted",
+    "solana",
+    "sysvar",
+    "Undelegate",
+    "undelegated",
+    "UNDELEGATION",
+    "vaas",
+    "Zeroable"
+  ]
 }

--- a/staking/Cargo.lock
+++ b/staking/Cargo.lock
@@ -1788,6 +1788,8 @@ dependencies = [
  "publisher-caps",
  "pyth-staking-program",
  "pythnet-sdk",
+ "quickcheck",
+ "quickcheck_macros",
  "serde_json",
  "serde_wormhole",
  "solana-cli-output",

--- a/staking/integration-tests/Cargo.toml
+++ b/staking/integration-tests/Cargo.toml
@@ -20,3 +20,7 @@ pythnet-sdk = {version = "2.3.0", features = ["test-utils"]}
 serde_json = "1.0.125"
 solana-cli-output = "1.18.16"
 spl-governance = { version = "4.0.0", features = ["no-entrypoint"] }
+
+[dev-dependencies]
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"

--- a/staking/integration-tests/src/integrity_pool/helper_functions.rs
+++ b/staking/integration-tests/src/integrity_pool/helper_functions.rs
@@ -7,26 +7,28 @@ use {
         airdrop_spl,
         initialize_ata,
     },
-    anchor_lang::solana_program::pubkey::Pubkey,
     integrity_pool::utils::types::FRAC_64_MULTIPLIER,
-    solana_sdk::signature::Keypair,
+    solana_sdk::{
+        signature::Keypair,
+        signer::Signer,
+    },
 };
 
 
 pub fn initialize_pool_reward_custody(
     svm: &mut litesvm::LiteSVM,
     payer: &Keypair,
-    pyth_token_mint: Pubkey,
+    pyth_token_mint: &Keypair,
 ) {
     let pool_config_pubkey = get_pool_config_address();
 
     // Create the ATA for the pool_config_pubkey if it doesn't exist
-    initialize_ata(svm, payer, pyth_token_mint, pool_config_pubkey).unwrap();
+    initialize_ata(svm, payer, pyth_token_mint.pubkey(), pool_config_pubkey).unwrap();
 
     airdrop_spl(
         svm,
         payer,
-        get_pool_reward_custody_address(pyth_token_mint),
+        get_pool_reward_custody_address(pyth_token_mint.pubkey()),
         pyth_token_mint,
         1_000_000 * FRAC_64_MULTIPLIER,
     );

--- a/staking/integration-tests/src/integrity_pool/instructions.rs
+++ b/staking/integration-tests/src/integrity_pool/instructions.rs
@@ -10,7 +10,7 @@ use {
         staking::pda::{
             get_config_address,
             get_stake_account_custody_address,
-            get_stake_account_custory_authority_address,
+            get_stake_account_custody_authority_address,
             get_stake_account_metadata_address,
             get_target_address,
         },
@@ -478,7 +478,7 @@ pub fn slash(
     let delegation_record = get_delegation_record_address(publisher, stake_account_positions);
     let stake_account_metadata = get_stake_account_metadata_address(stake_account_positions);
     let stake_account_custody = get_stake_account_custody_address(stake_account_positions);
-    let custody_authority = get_stake_account_custory_authority_address(stake_account_positions);
+    let custody_authority = get_stake_account_custody_authority_address(stake_account_positions);
     let config = get_config_address();
     let target_account = get_target_address();
 

--- a/staking/integration-tests/src/integrity_pool/instructions.rs
+++ b/staking/integration-tests/src/integrity_pool/instructions.rs
@@ -323,7 +323,10 @@ pub fn merge_delegation_positions(
         merge_delegation_positions_accs.to_account_metas(None),
     );
     let merge_delegation_positions_ix = Transaction::new_signed_with_payer(
-        &[merge_delegation_positions_ix],
+        &[
+            merge_delegation_positions_ix,
+            ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+        ],
         Some(&payer.pubkey()),
         &[&payer],
         svm.latest_blockhash(),
@@ -506,7 +509,10 @@ pub fn slash(
     );
 
     let slash_tx = Transaction::new_signed_with_payer(
-        &[slash_ix],
+        &[
+            slash_ix,
+            ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+        ],
         Some(&payer.pubkey()),
         &[payer],
         svm.latest_blockhash(),

--- a/staking/integration-tests/src/publisher_caps/helper_functions.rs
+++ b/staking/integration-tests/src/publisher_caps/helper_functions.rs
@@ -7,7 +7,7 @@ use {
         },
         utils::{
             build_encoded_vaa_account_from_vaa,
-            create_dummy_publisher_caps_message,
+            create_publisher_caps_message,
             deserialize_accumulator_update_data,
         },
     },
@@ -18,10 +18,13 @@ use {
         PublisherCaps,
         PRICE_FEEDS_EMITTER_ADDRESS,
     },
-    pythnet_sdk::test_utils::{
-        create_accumulator_message,
-        create_dummy_price_feed_message,
-        DataSource,
+    pythnet_sdk::{
+        messages::Message,
+        test_utils::{
+            create_accumulator_message,
+            create_dummy_price_feed_message,
+            DataSource,
+        },
     },
     solana_sdk::{
         pubkey::Pubkey,
@@ -30,14 +33,11 @@ use {
     std::cmp::min,
 };
 
-pub fn post_publisher_caps(
+pub fn write_and_verify_publisher_caps(
     svm: &mut LiteSVM,
     payer: &Keypair,
-    first_publisher: Pubkey,
-    first_publisher_cap: u64,
+    publisher_caps_message: Message,
 ) -> Pubkey {
-    let publisher_caps_message =
-        create_dummy_publisher_caps_message(svm, first_publisher, first_publisher_cap);
     let feed_1 = create_dummy_price_feed_message(100);
     let message = create_accumulator_message(
         &[&feed_1, &publisher_caps_message],
@@ -76,4 +76,26 @@ pub fn post_publisher_caps(
     verify_publisher_caps(svm, payer, publisher_caps, encoded_vaa, merkle_proofs).unwrap();
 
     publisher_caps
+}
+
+pub fn post_publisher_caps(
+    svm: &mut LiteSVM,
+    payer: &Keypair,
+    publishers: Vec<Pubkey>,
+    publisher_caps: Vec<u64>,
+) -> Pubkey {
+    let publisher_caps_message =
+        create_publisher_caps_message(svm, publishers, publisher_caps, false);
+    write_and_verify_publisher_caps(svm, payer, publisher_caps_message)
+}
+
+pub fn post_dummy_publisher_caps(
+    svm: &mut LiteSVM,
+    payer: &Keypair,
+    first_publisher: Pubkey,
+    first_publisher_cap: u64,
+) -> Pubkey {
+    let publisher_caps_message =
+        create_publisher_caps_message(svm, vec![first_publisher], vec![first_publisher_cap], true);
+    write_and_verify_publisher_caps(svm, payer, publisher_caps_message)
 }

--- a/staking/integration-tests/src/publisher_caps/utils.rs
+++ b/staking/integration-tests/src/publisher_caps/utils.rs
@@ -107,7 +107,8 @@ pub fn create_publisher_caps_message(
     }
 
     if fill_with_dummy {
-        for i in publishers.len()..MAX_CAPS {
+        // we leave the last publisher slot empty
+        for i in publishers.len()..MAX_CAPS - 1 {
             caps.push(PublisherStakeCap {
                 publisher: get_dummy_publisher(i).to_bytes(),
                 cap:       i as u64,

--- a/staking/integration-tests/src/publisher_caps/utils.rs
+++ b/staking/integration-tests/src/publisher_caps/utils.rs
@@ -90,25 +90,29 @@ pub fn deserialize_accumulator_update_data(
 }
 
 
-pub fn create_dummy_publisher_caps_message(
+pub fn create_publisher_caps_message(
     svm: &mut LiteSVM,
-    first_publisher: Pubkey,
-    first_publisher_cap: u64,
+    publishers: Vec<Pubkey>,
+    publisher_caps: Vec<u64>,
+    fill_with_dummy: bool,
 ) -> Message {
     let timestamp = svm.get_sysvar::<Clock>().unix_timestamp;
     let mut caps: Vec<PublisherStakeCap> = vec![];
 
-    caps.push(PublisherStakeCap {
-        publisher: first_publisher.to_bytes(),
-        cap:       first_publisher_cap,
-    });
-
-
-    for i in 1..MAX_CAPS {
+    for (publisher, cap) in publishers.iter().zip(publisher_caps.iter()) {
         caps.push(PublisherStakeCap {
-            publisher: get_dummy_publisher(i).to_bytes(),
-            cap:       i as u64,
+            publisher: publisher.to_bytes(),
+            cap:       *cap,
         });
+    }
+
+    if fill_with_dummy {
+        for i in publishers.len()..MAX_CAPS {
+            caps.push(PublisherStakeCap {
+                publisher: get_dummy_publisher(i).to_bytes(),
+                cap:       i as u64,
+            });
+        }
     }
 
     // publisher caps should always be sorted

--- a/staking/integration-tests/src/solana/instructions.rs
+++ b/staking/integration-tests/src/solana/instructions.rs
@@ -96,7 +96,7 @@ pub fn init_mint_account(svm: &mut litesvm::LiteSVM, payer: &Keypair, pyth_token
             spl_token::instruction::initialize_mint(
                 &spl_token::id(),
                 &pyth_token_mint.pubkey(),
-                &payer.pubkey(),
+                &pyth_token_mint.pubkey(),
                 None,
                 0,
             )
@@ -113,22 +113,22 @@ pub fn airdrop_spl(
     svm: &mut litesvm::LiteSVM,
     payer: &Keypair,
     destination: Pubkey,
-    mint: Pubkey,
+    mint: &Keypair,
     amount: u64,
 ) {
     let mint_to_ix = spl_token::instruction::mint_to(
         &spl_token::id(),
-        &mint,
+        &mint.pubkey(),
         &destination,
-        &payer.pubkey(),
-        &[&payer.pubkey()],
+        &mint.pubkey(),
+        &[&payer.pubkey(), &mint.pubkey()],
         amount,
     )
     .unwrap();
     let mint_to_tx = Transaction::new_signed_with_payer(
         &[mint_to_ix],
         Some(&payer.pubkey()),
-        &[&payer],
+        &[&payer, &mint],
         svm.latest_blockhash(),
     );
     svm.send_transaction(mint_to_tx).unwrap();

--- a/staking/integration-tests/src/solana/utils.rs
+++ b/staking/integration-tests/src/solana/utils.rs
@@ -3,7 +3,6 @@ use {
     anchor_lang::{
         prelude::borsh::BorshDeserialize,
         AccountDeserialize,
-        AnchorDeserialize,
     },
     bytemuck::{
         Pod,
@@ -17,7 +16,7 @@ use {
 };
 
 
-pub fn fetch_account_data<T: AnchorDeserialize + AccountDeserialize>(
+pub fn fetch_account_data<T: AccountDeserialize>(
     svm: &mut litesvm::LiteSVM,
     account: &Pubkey,
 ) -> T {

--- a/staking/integration-tests/src/staking/helper_functions.rs
+++ b/staking/integration-tests/src/staking/helper_functions.rs
@@ -16,7 +16,6 @@ use {
     solana_sdk::{
         pubkey::Pubkey,
         signature::Keypair,
-        signer::Signer,
     },
 };
 
@@ -48,7 +47,7 @@ pub fn initialize_new_stake_account(
             svm,
             payer,
             stake_account_custody,
-            pyth_token_mint.pubkey(),
+            pyth_token_mint,
             STAKED_TOKENS,
         );
     }

--- a/staking/integration-tests/src/staking/instructions.rs
+++ b/staking/integration-tests/src/staking/instructions.rs
@@ -197,6 +197,64 @@ pub fn create_position(
     svm.send_transaction(create_position_tx).unwrap();
 }
 
+pub fn close_position(
+    svm: &mut litesvm::LiteSVM,
+    payer: &Keypair,
+    stake_account_positions: Pubkey,
+    target_with_parameters: TargetWithParameters,
+    pool_authority: Option<&Keypair>,
+    amount: frac64,
+    index: u8,
+) -> TransactionResult {
+    let config_pubkey = get_config_address();
+    let stake_account_metadata = get_stake_account_metadata_address(stake_account_positions);
+    let stake_account_custody = get_stake_account_custody_address(stake_account_positions);
+
+    let close_position_data = staking::instruction::ClosePosition {
+        target_with_parameters,
+        amount,
+        index,
+    };
+
+    let target_account = match target_with_parameters {
+        TargetWithParameters::Voting => Some(get_target_address()),
+        TargetWithParameters::IntegrityPool { .. } => None,
+    };
+
+    let close_position_accs = staking::accounts::ClosePosition {
+        config: config_pubkey,
+        stake_account_metadata,
+        stake_account_positions,
+        stake_account_custody,
+        owner: payer.pubkey(),
+        target_account,
+        pool_authority: pool_authority.map(|k| k.pubkey()),
+        system_program: system_program::ID,
+    };
+
+    let create_position_ix = Instruction::new_with_bytes(
+        staking::ID,
+        &close_position_data.data(),
+        close_position_accs.to_account_metas(None),
+    );
+
+
+    let mut signing_keypairs: Vec<&Keypair> = vec![&payer];
+
+    if let Some(pool_authority) = pool_authority {
+        signing_keypairs.push(pool_authority);
+    }
+
+    let create_position_tx = Transaction::new_signed_with_payer(
+        &[create_position_ix],
+        Some(&payer.pubkey()),
+        signing_keypairs.as_slice(),
+        svm.latest_blockhash(),
+    );
+
+    svm.send_transaction(create_position_tx)
+}
+
 pub fn create_stake_account(
     svm: &mut litesvm::LiteSVM,
     payer: &Keypair,

--- a/staking/integration-tests/src/staking/instructions.rs
+++ b/staking/integration-tests/src/staking/instructions.rs
@@ -4,7 +4,7 @@ use {
         get_config_address_bump,
         get_max_voter_record_address,
         get_stake_account_custody_address,
-        get_stake_account_custory_authority_address,
+        get_stake_account_custody_authority_address,
         get_stake_account_metadata_address,
         get_target_address,
         get_voter_record_address,
@@ -263,7 +263,7 @@ pub fn create_stake_account(
 ) -> TransactionResult {
     let stake_account_metadata = get_stake_account_metadata_address(stake_account_positions);
     let stake_account_custody = get_stake_account_custody_address(stake_account_positions);
-    let custody_authority = get_stake_account_custory_authority_address(stake_account_positions);
+    let custody_authority = get_stake_account_custody_authority_address(stake_account_positions);
     let config_account = get_config_address();
 
     let create_stake_account_data = staking::instruction::CreateStakeAccount {
@@ -347,7 +347,7 @@ pub fn slash_staking(
     let stake_account_metadata = get_stake_account_metadata_address(stake_account_positions);
     let stake_account_custody = get_stake_account_custody_address(stake_account_positions);
     let stake_account_authority =
-        get_stake_account_custory_authority_address(stake_account_positions);
+        get_stake_account_custody_authority_address(stake_account_positions);
 
     let slash_account_accs = staking::accounts::SlashAccount {
         config: config_pubkey,

--- a/staking/integration-tests/src/staking/pda.rs
+++ b/staking/integration-tests/src/staking/pda.rs
@@ -45,7 +45,7 @@ pub fn get_stake_account_custody_address(stake_account_positions: Pubkey) -> Pub
     .0
 }
 
-pub fn get_stake_account_custory_authority_address(stake_account_positions: Pubkey) -> Pubkey {
+pub fn get_stake_account_custody_authority_address(stake_account_positions: Pubkey) -> Pubkey {
     Pubkey::find_program_address(
         &[
             staking::context::AUTHORITY_SEED.as_bytes(),

--- a/staking/integration-tests/tests/advance.rs
+++ b/staking/integration-tests/tests/advance.rs
@@ -11,7 +11,7 @@ use {
             update_delegation_fee,
         },
         publisher_caps::{
-            helper_functions::post_publisher_caps,
+            helper_functions::post_dummy_publisher_caps,
             utils::get_dummy_publisher,
         },
         setup::{
@@ -65,7 +65,7 @@ fn test_advance() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index,
+        maybe_publisher_index,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -74,6 +74,7 @@ fn test_advance() {
         init_publishers: true,
     });
 
+    let publisher_index = maybe_publisher_index.unwrap();
     let pool_data = fetch_account_data_bytemuck::<PoolData>(&mut svm, &pool_data_pubkey);
 
     let mut publisher_pubkeys = (1..MAX_PUBLISHERS)
@@ -92,8 +93,10 @@ fn test_advance() {
     }
     assert_eq!(pool_data.last_updated_epoch, 2);
 
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
-    let publisher_caps_2 = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps_2 =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     assert_anchor_program_error!(
         advance(&mut svm, &payer, publisher_caps),
         IntegrityPoolError::PoolDataAlreadyUpToDate,
@@ -119,7 +122,7 @@ fn test_advance_reward_events() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index,
+        maybe_publisher_index,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -128,6 +131,7 @@ fn test_advance_reward_events() {
         init_publishers: true,
     });
 
+    let publisher_index = maybe_publisher_index.unwrap();
     let stake_account_positions =
         initialize_new_stake_account(&mut svm, &payer, &pyth_token_mint, true, true);
 
@@ -144,7 +148,8 @@ fn test_advance_reward_events() {
     advance_n_epochs(&mut svm, &payer, 1);
     assert_eq!(get_current_epoch(&mut svm), STARTING_EPOCH + 1);
 
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
     delegate(
@@ -160,13 +165,15 @@ fn test_advance_reward_events() {
     advance_n_epochs(&mut svm, &payer, 8);
     assert_eq!(get_current_epoch(&mut svm), STARTING_EPOCH + 9);
 
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
     advance_n_epochs(&mut svm, &payer, 1);
     assert_eq!(get_current_epoch(&mut svm), STARTING_EPOCH + 10);
 
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
     let pool_data = fetch_account_data_bytemuck::<PoolData>(&mut svm, &pool_data_pubkey);
@@ -216,7 +223,7 @@ fn test_reward_events_with_delegation_fee() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority,
-        publisher_index,
+        maybe_publisher_index,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -224,6 +231,7 @@ fn test_reward_events_with_delegation_fee() {
         init_pool_data:  true,
         init_publishers: true,
     });
+    let publisher_index = maybe_publisher_index.unwrap();
 
     let stake_account_positions =
         initialize_new_stake_account(&mut svm, &payer, &pyth_token_mint, true, true);
@@ -271,7 +279,7 @@ fn test_reward_events_with_delegation_fee() {
 
     advance_n_epochs(&mut svm, &payer, 2);
 
-    let publisher_caps = post_publisher_caps(
+    let publisher_caps = post_dummy_publisher_caps(
         &mut svm,
         &payer,
         publisher_keypair.pubkey(),
@@ -377,7 +385,7 @@ fn test_reward_after_undelegate() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index: _,
+        maybe_publisher_index: _,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -401,7 +409,7 @@ fn test_reward_after_undelegate() {
 
     advance_n_epochs(&mut svm, &payer, 1);
 
-    let publisher_caps = post_publisher_caps(
+    let publisher_caps = post_dummy_publisher_caps(
         &mut svm,
         &payer,
         publisher_keypair.pubkey(),
@@ -433,7 +441,7 @@ fn test_reward_after_undelegate() {
 
     advance_n_epochs(&mut svm, &payer, 1);
 
-    let publisher_caps = post_publisher_caps(
+    let publisher_caps = post_dummy_publisher_caps(
         &mut svm,
         &payer,
         publisher_keypair.pubkey(),

--- a/staking/integration-tests/tests/claim.rs
+++ b/staking/integration-tests/tests/claim.rs
@@ -8,7 +8,7 @@ use {
             advance_delegation_record,
             delegate,
         },
-        publisher_caps::helper_functions::post_publisher_caps,
+        publisher_caps::helper_functions::post_dummy_publisher_caps,
         setup::{
             setup,
             SetupProps,
@@ -42,7 +42,7 @@ fn test_claim() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index: _,
+        maybe_publisher_index: _,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -68,7 +68,7 @@ fn test_claim() {
 
     advance_n_epochs(&mut svm, &payer, 1);
 
-    let publisher_caps = post_publisher_caps(
+    let publisher_caps = post_dummy_publisher_caps(
         &mut svm,
         &payer,
         publisher_keypair.pubkey(),
@@ -104,7 +104,7 @@ fn test_claim() {
 
     advance_n_epochs(&mut svm, &payer, 1);
 
-    let publisher_caps = post_publisher_caps(
+    let publisher_caps = post_dummy_publisher_caps(
         &mut svm,
         &payer,
         publisher_keypair.pubkey(),
@@ -142,7 +142,7 @@ fn test_claim() {
     advance_n_epochs(&mut svm, &payer, 3);
 
     // cap for epoch x + 2 -> x + 4 will be 1.5 PYTH
-    let publisher_caps = post_publisher_caps(
+    let publisher_caps = post_dummy_publisher_caps(
         &mut svm,
         &payer,
         publisher_keypair.pubkey(),
@@ -188,7 +188,7 @@ fn test_lost_reward() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index: _,
+        maybe_publisher_index: _,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -216,7 +216,7 @@ fn test_lost_reward() {
     for _ in 0..20 {
         advance_n_epochs(&mut svm, &payer, 10);
 
-        let publisher_caps = post_publisher_caps(
+        let publisher_caps = post_dummy_publisher_caps(
             &mut svm,
             &payer,
             publisher_keypair.pubkey(),
@@ -262,7 +262,7 @@ fn test_correct_position_states() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index: _,
+        maybe_publisher_index: _,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -288,7 +288,7 @@ fn test_correct_position_states() {
 
     advance_n_epochs(&mut svm, &payer, 1);
 
-    let publisher_caps = post_publisher_caps(
+    let publisher_caps = post_dummy_publisher_caps(
         &mut svm,
         &payer,
         publisher_keypair.pubkey(),
@@ -308,7 +308,7 @@ fn test_correct_position_states() {
 
     advance_n_epochs(&mut svm, &payer, 2);
 
-    let publisher_caps = post_publisher_caps(
+    let publisher_caps = post_dummy_publisher_caps(
         &mut svm,
         &payer,
         publisher_keypair.pubkey(),
@@ -352,7 +352,7 @@ fn test_advance_delegation_record_permissionlessness() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index: _,
+        maybe_publisher_index: _,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -378,7 +378,7 @@ fn test_advance_delegation_record_permissionlessness() {
 
     advance_n_epochs(&mut svm, &payer, 2);
 
-    let publisher_caps = post_publisher_caps(
+    let publisher_caps = post_dummy_publisher_caps(
         &mut svm,
         &payer,
         publisher_keypair.pubkey(),

--- a/staking/integration-tests/tests/delegate.rs
+++ b/staking/integration-tests/tests/delegate.rs
@@ -10,7 +10,7 @@ use {
             },
             pda::get_delegation_record_address,
         },
-        publisher_caps::helper_functions::post_publisher_caps,
+        publisher_caps::helper_functions::post_dummy_publisher_caps,
         setup::{
             setup,
             SetupProps,
@@ -52,7 +52,7 @@ fn test_delegate() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index,
+        maybe_publisher_index,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -60,6 +60,7 @@ fn test_delegate() {
         init_pool_data:  true,
         init_publishers: true,
     });
+    let publisher_index = maybe_publisher_index.unwrap();
 
     let target_with_parameters = TargetWithParameters::IntegrityPool {
         publisher: publisher_keypair.pubkey(),
@@ -237,7 +238,8 @@ fn test_delegate() {
         0
     );
 
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
     let pool_data: PoolData = fetch_account_data_bytemuck(&mut svm, &pool_data_pubkey);
@@ -330,7 +332,8 @@ fn test_delegate() {
     }
 
     advance_n_epochs(&mut svm, &payer, 2); // two epochs at a time
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
 

--- a/staking/integration-tests/tests/initialize_pool.rs
+++ b/staking/integration-tests/tests/initialize_pool.rs
@@ -38,7 +38,7 @@ fn initialize_pool() {
         publisher_keypair: _,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index: _,
+        maybe_publisher_index: _,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -74,7 +74,7 @@ fn test_update_y() {
         publisher_keypair: _,
         pool_data_pubkey: _,
         reward_program_authority,
-        publisher_index: _,
+        maybe_publisher_index: _,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,

--- a/staking/integration-tests/tests/integrity_pool_slash.rs
+++ b/staking/integration-tests/tests/integrity_pool_slash.rs
@@ -1,5 +1,4 @@
 use {
-    anchor_lang::AccountDeserialize,
     anchor_spl::token::TokenAccount,
     integration_tests::{
         assert_anchor_program_error,
@@ -17,7 +16,7 @@ use {
                 get_slash_event_address,
             },
         },
-        publisher_caps::helper_functions::post_publisher_caps,
+        publisher_caps::helper_functions::post_dummy_publisher_caps,
         setup::{
             setup,
             SetupProps,
@@ -63,7 +62,7 @@ fn test_create_slash_event() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority,
-        publisher_index,
+        maybe_publisher_index,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -71,6 +70,7 @@ fn test_create_slash_event() {
         init_pool_data:  true,
         init_publishers: true,
     });
+    let publisher_index = maybe_publisher_index.unwrap();
 
     let slash_custody = create_token_account(&mut svm, &payer, &pyth_token_mint.pubkey()).pubkey();
     let slashed_publisher = publisher_keypair.pubkey();
@@ -217,7 +217,7 @@ fn test_slash() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority,
-        publisher_index,
+        maybe_publisher_index,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -225,6 +225,7 @@ fn test_slash() {
         init_pool_data:  true,
         init_publishers: true,
     });
+    let publisher_index = maybe_publisher_index.unwrap();
 
     let slash_custody = create_token_account(&mut svm, &payer, &pyth_token_mint.pubkey()).pubkey();
 
@@ -244,7 +245,8 @@ fn test_slash() {
 
     advance_n_epochs(&mut svm, &payer, 1);
 
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
     advance_delegation_record(
@@ -283,7 +285,8 @@ fn test_slash() {
         }
     );
 
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
     advance_delegation_record(
@@ -371,9 +374,7 @@ fn test_slash() {
     )
     .unwrap();
 
-    let slash_custody_data = svm.get_account(&slash_custody).unwrap();
-    let slash_custody_account =
-        TokenAccount::try_deserialize(&mut slash_custody_data.data.as_slice()).unwrap();
+    let slash_custody_account: TokenAccount = fetch_account_data(&mut svm, &slash_custody);
 
     // Slashed for epoch N + 1 -> 10 pyth * 5% = 0.5 pyth
     assert_eq!(slash_custody_account.amount, 10 * FRAC_64_MULTIPLIER / 20);
@@ -409,9 +410,7 @@ fn test_slash() {
     )
     .unwrap();
 
-    let slash_custody_data = svm.get_account(&slash_custody).unwrap();
-    let slash_custody_account =
-        TokenAccount::try_deserialize(&mut slash_custody_data.data.as_slice()).unwrap();
+    let slash_custody_account: TokenAccount = fetch_account_data(&mut svm, &slash_custody);
 
     // slashed for epoch N + 1 -> 9.5 pyth * 50% = 4.75 pyth
     assert_eq!(

--- a/staking/integration-tests/tests/max_positions.rs
+++ b/staking/integration-tests/tests/max_positions.rs
@@ -6,7 +6,7 @@ use {
             advance_delegation_record,
             delegate,
         },
-        publisher_caps::helper_functions::post_publisher_caps,
+        publisher_caps::helper_functions::post_dummy_publisher_caps,
         setup::{
             setup,
             SetupProps,
@@ -30,7 +30,7 @@ fn test_max_positions() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index: _,
+        maybe_publisher_index: _,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -72,7 +72,7 @@ fn test_max_positions() {
     for _ in 0..10 {
         advance_n_epochs(&mut svm, &payer, 10);
 
-        let publisher_caps = post_publisher_caps(
+        let publisher_caps = post_dummy_publisher_caps(
             &mut svm,
             &payer,
             publisher_keypair.pubkey(),
@@ -97,7 +97,7 @@ fn test_max_positions() {
     assert!(res.compute_units_consumed < 1_350_000);
 
     advance_n_epochs(&mut svm, &payer, 10);
-    let publisher_caps = post_publisher_caps(
+    let publisher_caps = post_dummy_publisher_caps(
         &mut svm,
         &payer,
         publisher_keypair.pubkey(),

--- a/staking/integration-tests/tests/merge_delegation_positions.rs
+++ b/staking/integration-tests/tests/merge_delegation_positions.rs
@@ -8,7 +8,7 @@ use {
             merge_delegation_positions,
             undelegate,
         },
-        publisher_caps::helper_functions::post_publisher_caps,
+        publisher_caps::helper_functions::post_dummy_publisher_caps,
         setup::{
             setup,
             SetupProps,
@@ -44,7 +44,7 @@ fn test_merge_delegation_positions() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index: _,
+        maybe_publisher_index: _,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -134,7 +134,8 @@ fn test_merge_delegation_positions() {
 
 
     advance_n_epochs(&mut svm, &payer, 1);
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
     assert_anchor_program_error!(
@@ -242,9 +243,9 @@ fn test_merge_delegation_positions() {
     );
 
     advance_n_epochs(&mut svm, &payer, 1);
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
-
 
     delegate(
         &mut svm,
@@ -376,7 +377,8 @@ fn test_merge_delegation_positions() {
     );
 
     advance_n_epochs(&mut svm, &payer, 1);
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
     advance_delegation_record(

--- a/staking/integration-tests/tests/set_publisher_stake_account.rs
+++ b/staking/integration-tests/tests/set_publisher_stake_account.rs
@@ -9,7 +9,7 @@ use {
             set_publisher_stake_account,
             undelegate,
         },
-        publisher_caps::helper_functions::post_publisher_caps,
+        publisher_caps::helper_functions::post_dummy_publisher_caps,
         setup::{
             setup,
             SetupProps,
@@ -43,7 +43,7 @@ fn test_set_publisher_stake_account() {
         publisher_keypair,
         pool_data_pubkey,
         reward_program_authority: _,
-        publisher_index,
+        maybe_publisher_index,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -51,6 +51,7 @@ fn test_set_publisher_stake_account() {
         init_pool_data:  true,
         init_publishers: true,
     });
+    let publisher_index = maybe_publisher_index.unwrap();
 
     let stake_account_positions =
         initialize_new_stake_account(&mut svm, &payer, &pyth_token_mint, true, true);
@@ -288,7 +289,8 @@ fn test_set_publisher_stake_account() {
 
     // new epoch
     advance_n_epochs(&mut svm, &payer, 1);
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
     advance_delegation_record(
@@ -340,7 +342,8 @@ fn test_set_publisher_stake_account() {
 
     // new epoch
     advance_n_epochs(&mut svm, &payer, 1);
-    let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
+    let publisher_caps =
+        post_dummy_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
     let pool_data: PoolData = fetch_account_data_bytemuck(&mut svm, &pool_data_pubkey);

--- a/staking/integration-tests/tests/stability.rs
+++ b/staking/integration-tests/tests/stability.rs
@@ -1,0 +1,833 @@
+use {
+    anchor_spl::token::TokenAccount,
+    integration_tests::{
+        assert_anchor_program_error,
+        integrity_pool::{
+            helper_functions::initialize_pool_reward_custody,
+            instructions::{
+                advance,
+                advance_delegation_record,
+                create_slash_event,
+                delegate,
+                merge_delegation_positions,
+                slash,
+                undelegate,
+                update_y,
+            },
+        },
+        publisher_caps::helper_functions::post_publisher_caps,
+        setup::{
+            setup,
+            SetupProps,
+            SetupResult,
+        },
+        solana::{
+            instructions::create_token_account,
+            utils::{
+                fetch_account_data,
+                fetch_account_data_bytemuck,
+                fetch_positions_account,
+            },
+        },
+        staking::{
+            helper_functions::initialize_new_stake_account,
+            instructions::{
+                close_position,
+                create_position,
+            },
+            pda::get_stake_account_custody_address,
+        },
+        utils::clock::{
+            advance_n_epochs,
+            get_current_epoch,
+        },
+    },
+    integrity_pool::{
+        state::pool::PoolData,
+        utils::{
+            clock::UNLOCKING_DURATION,
+            constants::MAX_PUBLISHERS,
+            types::FRAC_64_MULTIPLIER,
+        },
+    },
+    litesvm::LiteSVM,
+    quickcheck::{
+        Arbitrary,
+        Gen,
+        QuickCheck,
+    },
+    solana_sdk::{
+        pubkey::Pubkey,
+        signature::Keypair,
+        signer::Signer,
+    },
+    staking::{
+        error::ErrorCode as StakingErrorCode,
+        state::positions::{
+            Position,
+            PositionState,
+            Target,
+            TargetWithParameters,
+        },
+    },
+    std::{
+        cmp::min,
+        collections::HashMap,
+        convert::TryInto,
+        fmt::Debug,
+    },
+};
+
+// These constants define the parameters of the stability test.
+const MAX_DELEGATION_AMOUNT: u64 = 2 * FRAC_64_MULTIPLIER;
+const MAX_UNDELEGATION_AMOUNT: u64 = FRAC_64_MULTIPLIER / 10;
+const NUM_DELEGATORS: u64 = 1_000;
+const NUM_OPERATIONS: u64 = 10_000;
+const MAX_CAP: u64 = 100 * FRAC_64_MULTIPLIER;
+const Y: u64 = FRAC_64_MULTIPLIER / 10 / 52;
+
+#[derive(Debug)]
+struct KeypairWrapper(Keypair);
+
+impl Clone for KeypairWrapper {
+    fn clone(&self) -> Self {
+        KeypairWrapper(self.0.insecure_clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Operation {
+    Delegate {
+        publisher: usize,
+        delegator: usize,
+        amount:    u64,
+    },
+    Undelegate {
+        publisher: usize,
+        delegator: usize,
+        amount:    u64,
+    },
+    AdvanceDelegationRecord {
+        publisher: usize,
+        delegator: usize,
+    },
+    Advance {
+        cap: u64,
+    },
+    Slash {
+        publisher: usize,
+        amount:    u64,
+    },
+    MergePositions {
+        publisher: usize,
+        delegator: usize,
+    },
+    CreateGovernancePosition {
+        delegator: usize,
+        amount:    u64,
+    },
+    CloseGovernancePosition {
+        delegator: usize,
+        amount:    u64,
+    },
+}
+
+impl Operation {
+    fn get_name(&self) -> String {
+        match self {
+            Operation::Delegate { .. } => "Delegate".to_string(),
+            Operation::Undelegate { .. } => "Undelegate".to_string(),
+            Operation::AdvanceDelegationRecord { .. } => "AdvanceDelegationRecord".to_string(),
+            Operation::Advance { .. } => "Advance".to_string(),
+            Operation::Slash { .. } => "Slash".to_string(),
+            Operation::MergePositions { .. } => "MergePositions".to_string(),
+            Operation::CreateGovernancePosition { .. } => "CreateGovernancePosition".to_string(),
+            Operation::CloseGovernancePosition { .. } => "CloseGovernancePosition".to_string(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct StabilityTestProps {
+    operations: Vec<Operation>,
+    publishers: Vec<KeypairWrapper>,
+    delegators: Vec<KeypairWrapper>,
+}
+
+impl Debug for StabilityTestProps {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("StabilityTestProps")
+    }
+}
+
+impl Arbitrary for StabilityTestProps {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let publishers: Vec<KeypairWrapper> = (0..(MAX_PUBLISHERS - 10))
+            .map(|_| KeypairWrapper(Keypair::new()))
+            .collect();
+
+        let delegators: Vec<KeypairWrapper> = (0..NUM_DELEGATORS)
+            .map(|_| KeypairWrapper(Keypair::new()))
+            .collect();
+
+        let mut operations = vec![];
+        for _ in 0..NUM_OPERATIONS {
+            let operation = get_random_operation(g, &operations, &publishers, &delegators);
+            operations.push(operation);
+        }
+
+        StabilityTestProps {
+            operations,
+            publishers,
+            delegators,
+        }
+    }
+}
+
+type OperationWrapper =
+    Box<dyn Fn(&mut Gen, &[Operation], &[KeypairWrapper], &[KeypairWrapper]) -> Operation>;
+
+struct OperationWeight {
+    weight:    u64,
+    operation: OperationWrapper,
+}
+
+fn get_random_operation(
+    g: &mut Gen,
+    prev_operations: &[Operation],
+    publishers: &[KeypairWrapper],
+    delegators: &[KeypairWrapper],
+) -> Operation {
+    let operations = vec![
+        OperationWeight {
+            weight:    500,
+            operation: Box::new(
+                |g, _operations, publishers, delegators| Operation::Delegate {
+                    publisher: usize::arbitrary(g) % publishers.len(),
+                    delegator: usize::arbitrary(g) % delegators.len(),
+                    amount:    u64::arbitrary(g) % MAX_DELEGATION_AMOUNT + 1,
+                },
+            ),
+        },
+        OperationWeight {
+            weight:    250,
+            operation: Box::new(|g, operations, publishers, delegators| {
+                let del_ops: Vec<&Operation> = operations
+                    .iter()
+                    .filter(|op| matches!(op, Operation::Delegate { .. }))
+                    .collect();
+                let del_op = g.choose(&del_ops);
+                if let Some(Operation::Delegate {
+                    publisher,
+                    delegator,
+                    amount,
+                }) = del_op
+                {
+                    Operation::Undelegate {
+                        publisher: *publisher,
+                        delegator: *delegator,
+                        amount:    min(u64::arbitrary(g) % MAX_UNDELEGATION_AMOUNT + 1, *amount),
+                    }
+                } else {
+                    Operation::Undelegate {
+                        publisher: usize::arbitrary(g) % publishers.len(),
+                        delegator: usize::arbitrary(g) % delegators.len(),
+                        amount:    u64::arbitrary(g) % MAX_UNDELEGATION_AMOUNT + 1,
+                    }
+                }
+            }),
+        },
+        OperationWeight {
+            weight:    250,
+            operation: Box::new(|g, _operations, publishers, delegators| {
+                Operation::AdvanceDelegationRecord {
+                    publisher: usize::arbitrary(g) % publishers.len(),
+                    delegator: usize::arbitrary(g) % delegators.len(),
+                }
+            }),
+        },
+        OperationWeight {
+            weight:    10,
+            operation: Box::new(
+                |g, _operations, _publishers, _delegators| Operation::Advance {
+                    cap: u64::arbitrary(g) % MAX_CAP + 1,
+                },
+            ),
+        },
+        OperationWeight {
+            weight:    1,
+            operation: Box::new(|g, _operations, publishers, _delegators| Operation::Slash {
+                publisher: usize::arbitrary(g) % publishers.len(),
+                amount:    u64::arbitrary(g) % (FRAC_64_MULTIPLIER - 1) + 1,
+            }),
+        },
+        OperationWeight {
+            weight:    100,
+            operation: Box::new(|g, _operations, publishers, delegators| {
+                Operation::MergePositions {
+                    publisher: usize::arbitrary(g) % publishers.len(),
+                    delegator: usize::arbitrary(g) % delegators.len(),
+                }
+            }),
+        },
+        OperationWeight {
+            weight:    100,
+            operation: Box::new(|g, _operations, _publishers, delegators| {
+                Operation::CreateGovernancePosition {
+                    amount:    u64::arbitrary(g) % MAX_DELEGATION_AMOUNT + 1,
+                    delegator: usize::arbitrary(g) % delegators.len(),
+                }
+            }),
+        },
+        OperationWeight {
+            weight:    50,
+            operation: Box::new(|g, operations, _publishers, delegators| {
+                let cgp_ops: Vec<&Operation> = operations
+                    .iter()
+                    .filter(|op| matches!(op, Operation::CreateGovernancePosition { .. }))
+                    .collect();
+                let del_op = g.choose(&cgp_ops);
+                if let Some(Operation::CreateGovernancePosition { delegator, amount }) = del_op {
+                    Operation::CloseGovernancePosition {
+                        delegator: *delegator,
+                        amount:    min(u64::arbitrary(g) % MAX_UNDELEGATION_AMOUNT + 1, *amount),
+                    }
+                } else {
+                    Operation::CloseGovernancePosition {
+                        delegator: usize::arbitrary(g) % delegators.len(),
+                        amount:    u64::arbitrary(g) % MAX_UNDELEGATION_AMOUNT + 1,
+                    }
+                }
+            }),
+        },
+    ];
+
+    let total_weight: u64 = operations.iter().map(|op| op.weight).sum();
+    let rnd = u64::arbitrary(g) % total_weight;
+    let mut cumulative_weight = 0;
+
+    for op_weight in operations {
+        cumulative_weight += op_weight.weight;
+        if rnd < cumulative_weight {
+            return (op_weight.operation)(g, prev_operations, publishers, delegators);
+        }
+    }
+
+    unreachable!()
+}
+
+fn sanity_check_publisher(
+    svm: &mut LiteSVM,
+    pool_data_pubkey: Pubkey,
+    stake_accounts: &[Pubkey],
+    index: usize,
+) {
+    let pool_data: PoolData = fetch_account_data_bytemuck(svm, &pool_data_pubkey);
+    let publisher = pool_data.publishers[index];
+    let mut total_delegated = 0;
+    let mut delta: i64 = 0;
+
+    for stake_acoount in stake_accounts.iter() {
+        let mut stake_positions_account = fetch_positions_account(svm, stake_acoount);
+        let positions = stake_positions_account.to_dynamic_position_array();
+
+        for i in 0..positions.get_position_capacity() {
+            if let Some(position) = positions.read_position(i).unwrap() {
+                let position_state = position
+                    .get_current_position(get_current_epoch(svm), UNLOCKING_DURATION)
+                    .unwrap();
+                if matches!(position, Position {
+                        target_with_parameters: TargetWithParameters::IntegrityPool { publisher: p, .. },
+                        ..
+                    } if p == publisher
+                ) {
+                    if position_state == PositionState::LOCKED
+                        || position_state == PositionState::PREUNLOCKING
+                    {
+                        total_delegated += position.amount;
+                    }
+                    if position_state == PositionState::LOCKING {
+                        delta += position.amount as i64;
+                    }
+                    if position_state == PositionState::PREUNLOCKING {
+                        delta -= position.amount as i64;
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(delta == pool_data.del_state[index].delta_delegation);
+    assert!(total_delegated == pool_data.del_state[index].total_delegation);
+}
+
+fn sanity_check(svm: &mut LiteSVM, pool_data_pubkey: Pubkey, stake_accounts: &[Pubkey]) {
+    for i in 0..MAX_PUBLISHERS {
+        sanity_check_publisher(svm, pool_data_pubkey, stake_accounts, i);
+    }
+}
+
+fn handle_delegate_operation(
+    svm: &mut LiteSVM,
+    pool_data_pubkey: Pubkey,
+    delegator: &Keypair,
+    publisher: Pubkey,
+    amount: u64,
+    stake_account_positions: Pubkey,
+) -> bool {
+    let stake_account_custody = get_stake_account_custody_address(stake_account_positions);
+
+    let custody_data: TokenAccount = fetch_account_data(svm, &stake_account_custody);
+
+    let mut stake_positions_account = fetch_positions_account(svm, &stake_account_positions);
+    let positions = stake_positions_account.to_dynamic_position_array();
+
+    let mut total_delegate = 0;
+
+    for i in 0..positions.get_position_capacity() {
+        if let Some(position) = positions.read_position(i).unwrap() {
+            if position.target_with_parameters.get_target() == Target::IntegrityPool {
+                total_delegate += position.amount;
+            }
+        }
+    }
+
+    let res = delegate(
+        svm,
+        delegator,
+        publisher,
+        pool_data_pubkey,
+        stake_account_positions,
+        amount,
+    );
+
+    if total_delegate + amount > custody_data.amount {
+        assert_anchor_program_error!(res, StakingErrorCode::TooMuchExposureToIntegrityPool, 0);
+        false
+    } else {
+        res.unwrap();
+        true
+    }
+}
+
+fn test_stability(props: StabilityTestProps) {
+    let SetupResult {
+        mut svm,
+        payer,
+        pyth_token_mint,
+        publisher_keypair: _,
+        pool_data_pubkey,
+        reward_program_authority,
+        maybe_publisher_index: _,
+    } = setup(SetupProps {
+        init_config:     true,
+        init_target:     true,
+        init_mint:       true,
+        init_pool_data:  true,
+        init_publishers: false,
+    });
+
+    props.delegators.iter().for_each(|delegator| {
+        svm.airdrop(&delegator.0.pubkey(), 1_000_000_000).unwrap();
+    });
+
+    let stake_account_positions: Vec<Pubkey> = props
+        .delegators
+        .iter()
+        .enumerate()
+        .map(|(i, delegator)| {
+            if i % 100 == 0 {
+                println!(
+                    "creating stake account {} out of {}",
+                    i,
+                    props.delegators.len()
+                );
+            }
+            initialize_new_stake_account(&mut svm, &delegator.0, &pyth_token_mint, true, true)
+        })
+        .collect();
+
+    initialize_pool_reward_custody(&mut svm, &payer, &pyth_token_mint);
+
+    update_y(&mut svm, &payer, &reward_program_authority, Y).unwrap();
+
+    let publisher_caps = post_publisher_caps(
+        &mut svm,
+        &payer,
+        props.publishers.iter().map(|p| p.0.pubkey()).collect(),
+        vec![0; props.publishers.len()],
+    );
+    advance(&mut svm, &payer, publisher_caps).unwrap();
+
+    let mut operation_counts: HashMap<String, (u64, u64)> = HashMap::new();
+
+    operation_counts.insert(
+        "Delegate".to_string(),
+        (
+            0,
+            props
+                .operations
+                .iter()
+                .filter(|op| matches!(op, Operation::Delegate { .. }))
+                .count() as u64,
+        ),
+    );
+    operation_counts.insert(
+        "Undelegate".to_string(),
+        (
+            0,
+            props
+                .operations
+                .iter()
+                .filter(|op| matches!(op, Operation::Undelegate { .. }))
+                .count() as u64,
+        ),
+    );
+    operation_counts.insert(
+        "AdvanceDelegationRecord".to_string(),
+        (
+            0,
+            props
+                .operations
+                .iter()
+                .filter(|op| matches!(op, Operation::AdvanceDelegationRecord { .. }))
+                .count() as u64,
+        ),
+    );
+    operation_counts.insert(
+        "Advance".to_string(),
+        (
+            0,
+            props
+                .operations
+                .iter()
+                .filter(|op| matches!(op, Operation::Advance { .. }))
+                .count() as u64,
+        ),
+    );
+    operation_counts.insert(
+        "Slash".to_string(),
+        (
+            0,
+            props
+                .operations
+                .iter()
+                .filter(|op| matches!(op, Operation::Slash { .. }))
+                .count() as u64,
+        ),
+    );
+    operation_counts.insert(
+        "MergePositions".to_string(),
+        (
+            0,
+            props
+                .operations
+                .iter()
+                .filter(|op| matches!(op, Operation::MergePositions { .. }))
+                .count() as u64,
+        ),
+    );
+    operation_counts.insert(
+        "CreateGovernancePosition".to_string(),
+        (
+            0,
+            props
+                .operations
+                .iter()
+                .filter(|op| matches!(op, Operation::CreateGovernancePosition { .. }))
+                .count() as u64,
+        ),
+    );
+    operation_counts.insert(
+        "CloseGovernancePosition".to_string(),
+        (
+            0,
+            props
+                .operations
+                .iter()
+                .filter(|op| matches!(op, Operation::CloseGovernancePosition { .. }))
+                .count() as u64,
+        ),
+    );
+
+    for (i, operation) in props.operations.iter().enumerate() {
+        if i % 100 == 0 {
+            println!("opertaion {} out of {}", i, props.operations.len());
+        }
+
+        if i % 100 == 0 {
+            sanity_check(&mut svm, pool_data_pubkey, &stake_account_positions);
+        }
+
+        svm.expire_blockhash();
+        match operation {
+            Operation::Delegate {
+                publisher,
+                delegator,
+                amount,
+            } => {
+                let publisher_pubkey = props.publishers[*publisher].0.pubkey();
+                let success = handle_delegate_operation(
+                    &mut svm,
+                    pool_data_pubkey,
+                    &props.delegators[*delegator].0,
+                    publisher_pubkey,
+                    *amount,
+                    stake_account_positions[*delegator],
+                );
+
+                let pool_data: PoolData = fetch_account_data_bytemuck(&mut svm, &pool_data_pubkey);
+                let p_index = pool_data.get_publisher_index(&publisher_pubkey).unwrap();
+                sanity_check_publisher(
+                    &mut svm,
+                    pool_data_pubkey,
+                    &stake_account_positions,
+                    p_index,
+                );
+
+                operation_counts.get_mut(&operation.get_name()).unwrap().0 += success as u64;
+            }
+            Operation::Undelegate {
+                publisher,
+                delegator,
+                amount,
+            } => {
+                let publisher_pubkey = props.publishers[*publisher].0.pubkey();
+                let mut stake_positions_account =
+                    fetch_positions_account(&mut svm, &stake_account_positions[*delegator]);
+                let positions = stake_positions_account.to_dynamic_position_array();
+
+                let mut index: u8 = 0;
+                let mut position_value = 0;
+                for i in 0..positions.get_position_capacity() {
+                    if let Some(position) = positions.read_position(i).unwrap() {
+                        let position_state = position
+                            .get_current_position(get_current_epoch(&mut svm), UNLOCKING_DURATION)
+                            .unwrap();
+                        if matches!(position, Position {
+                                target_with_parameters: TargetWithParameters::IntegrityPool { publisher: p, .. },
+                                ..
+                            } if p == props.publishers[*publisher].0.pubkey()
+                        ) && (position_state == PositionState::LOCKED
+                            || position_state == PositionState::LOCKING)
+                        {
+                            index = i.try_into().unwrap();
+                            position_value = position.amount;
+                            break;
+                        }
+                    }
+                }
+
+                advance_delegation_record(
+                    &mut svm,
+                    &props.delegators[*delegator].0,
+                    props.publishers[*publisher].0.pubkey(),
+                    stake_account_positions[*delegator],
+                    pyth_token_mint.pubkey(),
+                    pool_data_pubkey,
+                    None,
+                )
+                .unwrap();
+
+                if position_value == 0 {
+                    continue;
+                }
+
+                undelegate(
+                    &mut svm,
+                    &props.delegators[*delegator].0,
+                    props.publishers[*publisher].0.pubkey(),
+                    pool_data_pubkey,
+                    stake_account_positions[*delegator],
+                    index,
+                    min(*amount, position_value),
+                )
+                .unwrap();
+
+                let pool_data: PoolData = fetch_account_data_bytemuck(&mut svm, &pool_data_pubkey);
+                let p_index = pool_data.get_publisher_index(&publisher_pubkey).unwrap();
+                sanity_check_publisher(
+                    &mut svm,
+                    pool_data_pubkey,
+                    &stake_account_positions,
+                    p_index,
+                );
+
+                operation_counts.get_mut(&operation.get_name()).unwrap().0 += 1;
+            }
+            Operation::AdvanceDelegationRecord {
+                publisher,
+                delegator,
+            } => {
+                advance_delegation_record(
+                    &mut svm,
+                    &props.delegators[*delegator].0,
+                    props.publishers[*publisher].0.pubkey(),
+                    stake_account_positions[*delegator],
+                    pyth_token_mint.pubkey(),
+                    pool_data_pubkey,
+                    None,
+                )
+                .unwrap();
+                operation_counts.get_mut(&operation.get_name()).unwrap().0 += 1;
+            }
+            Operation::Advance { cap } => {
+                advance_n_epochs(&mut svm, &payer, 1);
+                let publisher_caps = post_publisher_caps(
+                    &mut svm,
+                    &payer,
+                    props.publishers.iter().map(|p| p.0.pubkey()).collect(),
+                    vec![*cap; props.publishers.len()],
+                );
+                advance(&mut svm, &payer, publisher_caps).unwrap();
+                sanity_check(&mut svm, pool_data_pubkey, &stake_account_positions);
+                operation_counts.get_mut(&operation.get_name()).unwrap().0 += 1;
+            }
+            Operation::Slash { publisher, amount } => {
+                let publisher_pubkey = props.publishers[*publisher].0.pubkey();
+                let slash_custody =
+                    create_token_account(&mut svm, &payer, &pyth_token_mint.pubkey());
+                let pool_data: PoolData = fetch_account_data_bytemuck(&mut svm, &pool_data_pubkey);
+                let p_index = pool_data.get_publisher_index(&publisher_pubkey).unwrap();
+                let index = pool_data.num_slash_events[p_index];
+
+                create_slash_event(
+                    &mut svm,
+                    &payer,
+                    &reward_program_authority,
+                    index,
+                    *amount,
+                    slash_custody.pubkey(),
+                    publisher_pubkey,
+                    pool_data_pubkey,
+                )
+                .unwrap();
+
+                for (i, delegator) in props.delegators.iter().enumerate() {
+                    let positions_pubkey = &stake_account_positions[i];
+
+                    advance_delegation_record(
+                        &mut svm,
+                        &delegator.0,
+                        publisher_pubkey,
+                        *positions_pubkey,
+                        pyth_token_mint.pubkey(),
+                        pool_data_pubkey,
+                        None,
+                    )
+                    .unwrap();
+
+                    slash(
+                        &mut svm,
+                        &payer,
+                        *positions_pubkey,
+                        index,
+                        slash_custody.pubkey(),
+                        publisher_pubkey,
+                        pool_data_pubkey,
+                    )
+                    .unwrap();
+                }
+                sanity_check(&mut svm, pool_data_pubkey, &stake_account_positions);
+                operation_counts.get_mut(&operation.get_name()).unwrap().0 += 1;
+            }
+            Operation::MergePositions {
+                publisher,
+                delegator,
+            } => {
+                advance_delegation_record(
+                    &mut svm,
+                    &props.delegators[*delegator].0,
+                    props.publishers[*publisher].0.pubkey(),
+                    stake_account_positions[*delegator],
+                    pyth_token_mint.pubkey(),
+                    pool_data_pubkey,
+                    None,
+                )
+                .unwrap();
+                merge_delegation_positions(
+                    &mut svm,
+                    &props.delegators[*delegator].0,
+                    props.publishers[*publisher].0.pubkey(),
+                    pool_data_pubkey,
+                    stake_account_positions[*delegator],
+                )
+                .unwrap();
+                sanity_check(&mut svm, pool_data_pubkey, &stake_account_positions);
+                operation_counts.get_mut(&operation.get_name()).unwrap().0 += 1;
+            }
+            Operation::CreateGovernancePosition { amount, delegator } => {
+                create_position(
+                    &mut svm,
+                    &props.delegators[*delegator].0,
+                    stake_account_positions[*delegator],
+                    TargetWithParameters::Voting {},
+                    None,
+                    *amount,
+                );
+                operation_counts.get_mut(&operation.get_name()).unwrap().0 += 1;
+            }
+            Operation::CloseGovernancePosition { delegator, amount } => {
+                let mut stake_positions_account =
+                    fetch_positions_account(&mut svm, &stake_account_positions[*delegator]);
+                let positions = stake_positions_account.to_dynamic_position_array();
+
+                let mut index: u8 = 0;
+                let mut position_value = 0;
+                for i in 0..positions.get_position_capacity() {
+                    if let Some(position) = positions.read_position(i).unwrap() {
+                        let position_state = position
+                            .get_current_position(get_current_epoch(&mut svm), UNLOCKING_DURATION)
+                            .unwrap();
+                        if matches!(
+                            position,
+                            Position {
+                                target_with_parameters: TargetWithParameters::Voting { .. },
+                                ..
+                            }
+                        ) && (position_state == PositionState::LOCKED
+                            || position_state == PositionState::LOCKING)
+                        {
+                            index = i.try_into().unwrap();
+                            position_value = position.amount;
+                            break;
+                        }
+                    }
+                }
+
+                if position_value == 0 {
+                    continue;
+                }
+
+                close_position(
+                    &mut svm,
+                    &props.delegators[*delegator].0,
+                    stake_account_positions[*delegator],
+                    TargetWithParameters::Voting {},
+                    None,
+                    min(*amount, position_value),
+                    index,
+                )
+                .unwrap();
+
+                operation_counts.get_mut(&operation.get_name()).unwrap().0 += 1;
+            }
+        }
+    }
+
+    println!("Operation counts:");
+    for (name, (count, total)) in operation_counts.iter() {
+        println!("{}: {}/{}", name, count, total);
+    }
+}
+
+
+/// This stability test runs a large number of random operations on the integrity pool program.
+/// It takes more than 5 minutes to run and is disabled by default.
+#[test]
+#[ignore]
+fn quickcheck_stability() {
+    QuickCheck::new()
+        .tests(1)
+        .quickcheck(test_stability as fn(StabilityTestProps))
+}

--- a/staking/integration-tests/tests/stability.rs
+++ b/staking/integration-tests/tests/stability.rs
@@ -382,12 +382,12 @@ fn handle_delegate_operation(
     let mut stake_positions_account = fetch_positions_account(svm, &stake_account_positions);
     let positions = stake_positions_account.to_dynamic_position_array();
 
-    let mut total_delegate = 0;
+    let mut total_delegated = 0;
 
     for i in 0..positions.get_position_capacity() {
         if let Some(position) = positions.read_position(i).unwrap() {
             if position.target_with_parameters.get_target() == Target::IntegrityPool {
-                total_delegate += position.amount;
+                total_delegated += position.amount;
             }
         }
     }
@@ -401,7 +401,7 @@ fn handle_delegate_operation(
         amount,
     );
 
-    if total_delegate + amount > custody_data.amount {
+    if total_delegated + amount > custody_data.amount {
         assert_anchor_program_error!(res, StakingErrorCode::TooMuchExposureToIntegrityPool, 0);
         false
     } else {

--- a/staking/integration-tests/tests/stability.rs
+++ b/staking/integration-tests/tests/stability.rs
@@ -327,8 +327,8 @@ fn sanity_check_publisher(
     let mut total_delegated = 0;
     let mut delta: i64 = 0;
 
-    for stake_acoount in stake_accounts.iter() {
-        let mut stake_positions_account = fetch_positions_account(svm, stake_acoount);
+    for stake_account in stake_accounts.iter() {
+        let mut stake_positions_account = fetch_positions_account(svm, stake_account);
         let positions = stake_positions_account.to_dynamic_position_array();
 
         for i in 0..positions.get_position_capacity() {
@@ -552,7 +552,7 @@ fn test_stability(props: StabilityTestProps) {
 
     for (i, operation) in props.operations.iter().enumerate() {
         if i % 100 == 0 {
-            println!("opertaion {} out of {}", i, props.operations.len());
+            println!("operation {} out of {}", i, props.operations.len());
         }
 
         if i % 100 == 0 {

--- a/staking/integration-tests/tests/stability.rs
+++ b/staking/integration-tests/tests/stability.rs
@@ -461,96 +461,12 @@ fn test_stability(props: StabilityTestProps) {
 
     let mut operation_counts: HashMap<String, (u64, u64)> = HashMap::new();
 
-    operation_counts.insert(
-        "Delegate".to_string(),
-        (
-            0,
-            props
-                .operations
-                .iter()
-                .filter(|op| matches!(op, Operation::Delegate { .. }))
-                .count() as u64,
-        ),
-    );
-    operation_counts.insert(
-        "Undelegate".to_string(),
-        (
-            0,
-            props
-                .operations
-                .iter()
-                .filter(|op| matches!(op, Operation::Undelegate { .. }))
-                .count() as u64,
-        ),
-    );
-    operation_counts.insert(
-        "AdvanceDelegationRecord".to_string(),
-        (
-            0,
-            props
-                .operations
-                .iter()
-                .filter(|op| matches!(op, Operation::AdvanceDelegationRecord { .. }))
-                .count() as u64,
-        ),
-    );
-    operation_counts.insert(
-        "Advance".to_string(),
-        (
-            0,
-            props
-                .operations
-                .iter()
-                .filter(|op| matches!(op, Operation::Advance { .. }))
-                .count() as u64,
-        ),
-    );
-    operation_counts.insert(
-        "Slash".to_string(),
-        (
-            0,
-            props
-                .operations
-                .iter()
-                .filter(|op| matches!(op, Operation::Slash { .. }))
-                .count() as u64,
-        ),
-    );
-    operation_counts.insert(
-        "MergePositions".to_string(),
-        (
-            0,
-            props
-                .operations
-                .iter()
-                .filter(|op| matches!(op, Operation::MergePositions { .. }))
-                .count() as u64,
-        ),
-    );
-    operation_counts.insert(
-        "CreateGovernancePosition".to_string(),
-        (
-            0,
-            props
-                .operations
-                .iter()
-                .filter(|op| matches!(op, Operation::CreateGovernancePosition { .. }))
-                .count() as u64,
-        ),
-    );
-    operation_counts.insert(
-        "CloseGovernancePosition".to_string(),
-        (
-            0,
-            props
-                .operations
-                .iter()
-                .filter(|op| matches!(op, Operation::CloseGovernancePosition { .. }))
-                .count() as u64,
-        ),
-    );
-
     for (i, operation) in props.operations.iter().enumerate() {
+        operation_counts
+            .entry(operation.get_name())
+            .or_insert((0, 0))
+            .1 += 1;
+
         if i % 100 == 0 {
             println!("operation {} out of {}", i, props.operations.len());
         }

--- a/staking/integration-tests/tests/staking_slash.rs
+++ b/staking/integration-tests/tests/staking_slash.rs
@@ -1,5 +1,4 @@
 use {
-    anchor_lang::AccountDeserialize,
     anchor_spl::token::TokenAccount,
     integration_tests::{
         assert_anchor_program_error,
@@ -54,7 +53,7 @@ fn test_staking_slash() {
         publisher_keypair,
         pool_data_pubkey: _,
         reward_program_authority: _,
-        publisher_index: _,
+        maybe_publisher_index: _,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,
@@ -148,9 +147,7 @@ fn test_staking_slash() {
     assert_eq!(pos1.amount, 75 * FRAC_64_MULTIPLIER);
     assert_eq!(pos1.target_with_parameters, TargetWithParameters::Voting);
 
-    let slash_account_data = svm.get_account(&slash_token_account.pubkey()).unwrap();
-    let slash_account =
-        TokenAccount::try_deserialize(&mut slash_account_data.data.as_slice()).unwrap();
+    let slash_account: TokenAccount = fetch_account_data(&mut svm, &slash_token_account.pubkey());
 
     assert_eq!(slash_account.amount, 25 * FRAC_64_MULTIPLIER);
 

--- a/staking/integration-tests/tests/voting.rs
+++ b/staking/integration-tests/tests/voting.rs
@@ -73,7 +73,7 @@ fn test_voting() {
         publisher_keypair: _,
         pool_data_pubkey: _,
         reward_program_authority: _,
-        publisher_index: _,
+        maybe_publisher_index: _,
     } = setup(SetupProps {
         init_config:     true,
         init_target:     true,

--- a/staking/programs/integrity-pool/src/context.rs
+++ b/staking/programs/integrity-pool/src/context.rs
@@ -180,7 +180,7 @@ pub struct Undelegate<'info> {
     #[account(seeds = [POOL_CONFIG.as_bytes()], bump, has_one = pool_data)]
     pub pool_config: Account<'info, PoolConfig>,
 
-    /// CHECK : The publisher will be checked againts data in the pool_data
+    /// CHECK : The publisher will be checked against data in the pool_data
     pub publisher: AccountInfo<'info>,
 
     #[account(


### PR DESCRIPTION
This PR adds a new test to check the stability of the integrity pool program after running a set number of random operation. It is disabled by default since it will take a long time to run.