### PR TITLE
refactor: make assert_anchor_error a macro

### DIFF
--- a/staking/integration-tests/src/utils/error.rs
+++ b/staking/integration-tests/src/utils/error.rs
@@ -1,23 +1,16 @@
-use {
-    litesvm::types::TransactionResult,
-    solana_sdk::{
-        instruction::InstructionError,
-        program_error::ProgramError,
-        transaction::TransactionError,
-    },
-};
-
-
-pub fn assert_anchor_program_error(
-    transaction_result: TransactionResult,
-    expected_error: anchor_lang::prelude::Error,
-    instruction_index: u8,
-) {
-    assert_eq!(
-        transaction_result.unwrap_err().err,
-        TransactionError::InstructionError(
-            instruction_index,
-            InstructionError::from(u64::from(ProgramError::from(expected_error,)))
-        )
-    );
+#[macro_export]
+macro_rules! assert_anchor_program_error {
+    ($transaction_result:expr, $expected_error:expr, $instruction_index:expr) => {
+        assert_eq!(
+            $transaction_result.unwrap_err().err,
+            solana_sdk::transaction::TransactionError::InstructionError(
+                $instruction_index,
+                solana_sdk::instruction::InstructionError::from(u64::from(
+                    solana_sdk::program_error::ProgramError::from(
+                        anchor_lang::prelude::Error::from($expected_error)
+                    )
+                ))
+            )
+        );
+    };
 }

--- a/staking/integration-tests/tests/advance.rs
+++ b/staking/integration-tests/tests/advance.rs
@@ -1,9 +1,7 @@
 use {
-    anchor_lang::{
-        prelude::Error,
-        AccountDeserialize,
-    },
+    anchor_lang::AccountDeserialize,
     integration_tests::{
+        assert_anchor_program_error,
         integrity_pool::instructions::{
             advance,
             advance_delegation_record,
@@ -36,7 +34,6 @@ use {
                 STAKED_TOKENS,
                 YIELD,
             },
-            error::assert_anchor_program_error,
         },
     },
     integrity_pool::{
@@ -97,19 +94,19 @@ fn test_advance() {
 
     let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     let publisher_caps_2 = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         advance(&mut svm, &payer, publisher_caps),
-        Error::from(IntegrityPoolError::PoolDataAlreadyUpToDate),
-        0,
+        IntegrityPoolError::PoolDataAlreadyUpToDate,
+        0
     );
 
     // one epoch later, the caps are outdated
     advance_n_epochs(&mut svm, &payer, 1);
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         advance(&mut svm, &payer, publisher_caps_2),
-        Error::from(IntegrityPoolError::OutdatedPublisherCaps),
-        0,
+        IntegrityPoolError::OutdatedPublisherCaps,
+        0
     );
 }
 

--- a/staking/integration-tests/tests/delegate.rs
+++ b/staking/integration-tests/tests/delegate.rs
@@ -1,5 +1,6 @@
 use {
     integration_tests::{
+        assert_anchor_program_error,
         integrity_pool::{
             instructions::{
                 advance,
@@ -21,10 +22,7 @@ use {
             fetch_positions_account,
         },
         staking::helper_functions::initialize_new_stake_account,
-        utils::{
-            clock::advance_n_epochs,
-            error::assert_anchor_program_error,
-        },
+        utils::clock::advance_n_epochs,
     },
     integrity_pool::{
         error::IntegrityPoolError,
@@ -134,7 +132,7 @@ fn test_delegate() {
     assert_eq!(delegation_record.last_epoch, 2);
 
     let fake_publisher = Pubkey::new_unique();
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         advance_delegation_record(
             &mut svm,
             &payer,
@@ -144,11 +142,11 @@ fn test_delegate() {
             pool_data_pubkey,
             None,
         ),
-        anchor_lang::error::Error::from(IntegrityPoolError::PublisherNotFound),
-        0,
+        IntegrityPoolError::PublisherNotFound,
+        0
     );
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         undelegate(
             &mut svm,
             &payer,
@@ -158,8 +156,8 @@ fn test_delegate() {
             0,
             50,
         ),
-        anchor_lang::error::ErrorCode::AccountNotInitialized.into(),
-        0,
+        anchor_lang::error::ErrorCode::AccountNotInitialized,
+        0
     );
 
     undelegate(
@@ -210,7 +208,7 @@ fn test_delegate() {
 
     advance_n_epochs(&mut svm, &payer, 1);
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         undelegate(
             &mut svm,
             &payer,
@@ -220,12 +218,12 @@ fn test_delegate() {
             0,
             10,
         ),
-        anchor_lang::error::Error::from(IntegrityPoolError::OutdatedDelegatorAccounting),
-        0,
+        IntegrityPoolError::OutdatedDelegatorAccounting,
+        0
     );
 
     svm.expire_blockhash();
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         advance_delegation_record(
             &mut svm,
             &payer,
@@ -235,8 +233,8 @@ fn test_delegate() {
             pool_data_pubkey,
             None,
         ),
-        anchor_lang::error::Error::from(IntegrityPoolError::OutdatedPublisherAccounting),
-        0,
+        IntegrityPoolError::OutdatedPublisherAccounting,
+        0
     );
 
     let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);

--- a/staking/integration-tests/tests/initialize_pool.rs
+++ b/staking/integration-tests/tests/initialize_pool.rs
@@ -1,5 +1,6 @@
 use {
     integration_tests::{
+        assert_anchor_program_error,
         integrity_pool::{
             instructions::{
                 create_pool_data_account,
@@ -13,10 +14,7 @@ use {
             SetupResult,
         },
         solana::utils::fetch_account_data,
-        utils::{
-            constants::YIELD,
-            error::assert_anchor_program_error,
-        },
+        utils::constants::YIELD,
     },
     integrity_pool::{
         error::IntegrityPoolError,
@@ -64,7 +62,7 @@ fn initialize_pool() {
         Pubkey::new_unique(),
         pyth_token_mint.pubkey(),
     );
-    assert_anchor_program_error(initialize_pool_2_res, ProgramError::Custom(0).into(), 1);
+    assert_anchor_program_error!(initialize_pool_2_res, ProgramError::Custom(0), 1);
 }
 
 #[test]
@@ -98,9 +96,9 @@ fn test_update_y() {
     // Trying to update the yield without the correct authority should fail
     let wrong_authority = Keypair::new();
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         update_y(&mut svm, &payer, &wrong_authority, 456),
-        IntegrityPoolError::InvalidRewardProgramAuthority.into(),
-        0,
+        IntegrityPoolError::InvalidRewardProgramAuthority,
+        0
     );
 }

--- a/staking/integration-tests/tests/integrity_pool_slash.rs
+++ b/staking/integration-tests/tests/integrity_pool_slash.rs
@@ -2,6 +2,7 @@ use {
     anchor_lang::AccountDeserialize,
     anchor_spl::token::TokenAccount,
     integration_tests::{
+        assert_anchor_program_error,
         integrity_pool::{
             instructions::{
                 advance,
@@ -31,10 +32,7 @@ use {
             },
         },
         staking::helper_functions::initialize_new_stake_account,
-        utils::{
-            clock::advance_n_epochs,
-            error::assert_anchor_program_error,
-        },
+        utils::clock::advance_n_epochs,
     },
     integrity_pool::{
         error::IntegrityPoolError,
@@ -77,7 +75,7 @@ fn test_create_slash_event() {
     let slash_custody = create_token_account(&mut svm, &payer, &pyth_token_mint.pubkey()).pubkey();
     let slashed_publisher = publisher_keypair.pubkey();
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         create_slash_event(
             &mut svm,
             &payer,
@@ -88,8 +86,8 @@ fn test_create_slash_event() {
             slashed_publisher,
             pool_data_pubkey,
         ),
-        IntegrityPoolError::InvalidSlashEventIndex.into(),
-        0,
+        IntegrityPoolError::InvalidSlashEventIndex,
+        0
     );
 
     create_slash_event(
@@ -140,7 +138,7 @@ fn test_create_slash_event() {
     assert_eq!(pool_data.num_slash_events[publisher_index], 3);
 
     svm.expire_blockhash();
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         create_slash_event(
             &mut svm,
             &payer,
@@ -151,10 +149,10 @@ fn test_create_slash_event() {
             slashed_publisher,
             pool_data_pubkey,
         ),
-        IntegrityPoolError::InvalidSlashEventIndex.into(),
-        0,
+        IntegrityPoolError::InvalidSlashEventIndex,
+        0
     );
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         create_slash_event(
             &mut svm,
             &payer,
@@ -165,11 +163,11 @@ fn test_create_slash_event() {
             slashed_publisher,
             pool_data_pubkey,
         ),
-        ProgramError::Custom(0).into(),
-        0,
+        ProgramError::Custom(0),
+        0
     );
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         create_slash_event(
             &mut svm,
             &payer,
@@ -181,8 +179,8 @@ fn test_create_slash_event() {
             slashed_publisher,
             pool_data_pubkey,
         ),
-        IntegrityPoolError::InvalidRewardProgramAuthority.into(),
-        0,
+        IntegrityPoolError::InvalidRewardProgramAuthority,
+        0
     );
 
     let slash_account_0: SlashEvent =
@@ -348,7 +346,7 @@ fn test_slash() {
         }
     );
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         slash(
             &mut svm,
             &payer,
@@ -358,8 +356,8 @@ fn test_slash() {
             publisher_keypair.pubkey(),
             pool_data_pubkey,
         ),
-        IntegrityPoolError::WrongSlashEventOrder.into(),
-        0,
+        IntegrityPoolError::WrongSlashEventOrder,
+        0
     );
 
     slash(

--- a/staking/integration-tests/tests/max_positions.rs
+++ b/staking/integration-tests/tests/max_positions.rs
@@ -1,5 +1,6 @@
 use {
     integration_tests::{
+        assert_anchor_program_error,
         integrity_pool::instructions::{
             advance,
             advance_delegation_record,
@@ -12,10 +13,7 @@ use {
             SetupResult,
         },
         staking::helper_functions::initialize_new_stake_account,
-        utils::{
-            clock::advance_n_epochs,
-            error::assert_anchor_program_error,
-        },
+        utils::clock::advance_n_epochs,
     },
     integrity_pool::utils::types::FRAC_64_MULTIPLIER,
     solana_sdk::signer::Signer,
@@ -58,7 +56,7 @@ fn test_max_positions() {
     }
 
     svm.expire_blockhash();
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         delegate(
             &mut svm,
             &payer,
@@ -67,8 +65,8 @@ fn test_max_positions() {
             stake_account_positions,
             100,
         ),
-        ErrorCode::TooManyPositions.into(),
-        0,
+        ErrorCode::TooManyPositions,
+        0
     );
 
     for _ in 0..10 {

--- a/staking/integration-tests/tests/merge_delegation_positions.rs
+++ b/staking/integration-tests/tests/merge_delegation_positions.rs
@@ -1,5 +1,6 @@
 use {
     integration_tests::{
+        assert_anchor_program_error,
         integrity_pool::instructions::{
             advance,
             advance_delegation_record,
@@ -19,10 +20,7 @@ use {
             helper_functions::initialize_new_stake_account,
             instructions::create_position,
         },
-        utils::{
-            clock::advance_n_epochs,
-            error::assert_anchor_program_error,
-        },
+        utils::clock::advance_n_epochs,
     },
     integrity_pool::error::IntegrityPoolError,
     solana_sdk::{
@@ -139,7 +137,7 @@ fn test_merge_delegation_positions() {
     let publisher_caps = post_publisher_caps(&mut svm, &payer, publisher_keypair.pubkey(), 50);
     advance(&mut svm, &payer, publisher_caps).unwrap();
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         merge_delegation_positions(
             &mut svm,
             &payer,
@@ -147,11 +145,11 @@ fn test_merge_delegation_positions() {
             pool_data_pubkey,
             stake_account_positions,
         ),
-        anchor_lang::error::Error::from(IntegrityPoolError::OutdatedDelegatorAccounting),
-        0,
+        IntegrityPoolError::OutdatedDelegatorAccounting,
+        0
     );
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         merge_delegation_positions(
             &mut svm,
             &payer,
@@ -159,8 +157,8 @@ fn test_merge_delegation_positions() {
             pool_data_pubkey,
             stake_account_positions,
         ),
-        anchor_lang::error::ErrorCode::AccountNotInitialized.into(),
-        0,
+        anchor_lang::error::ErrorCode::AccountNotInitialized,
+        0
     );
 
     delegate(

--- a/staking/integration-tests/tests/set_publisher_stake_account.rs
+++ b/staking/integration-tests/tests/set_publisher_stake_account.rs
@@ -1,9 +1,7 @@
 use {
-    anchor_lang::{
-        error::ErrorCode,
-        prelude::Error,
-    },
+    anchor_lang::error::ErrorCode,
     integration_tests::{
+        assert_anchor_program_error,
         integrity_pool::instructions::{
             advance,
             advance_delegation_record,
@@ -19,10 +17,7 @@ use {
         },
         solana::utils::fetch_account_data_bytemuck,
         staking::helper_functions::initialize_new_stake_account,
-        utils::{
-            clock::advance_n_epochs,
-            error::assert_anchor_program_error,
-        },
+        utils::clock::advance_n_epochs,
     },
     integrity_pool::{
         error::IntegrityPoolError,
@@ -65,7 +60,7 @@ fn test_set_publisher_stake_account() {
         initialize_new_stake_account(&mut svm, &payer, &pyth_token_mint, true, true);
 
     // payer tries to set publisher stake account
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         set_publisher_stake_account(
             &mut svm,
             &payer,
@@ -74,8 +69,8 @@ fn test_set_publisher_stake_account() {
             None,
             stake_account_positions,
         ),
-        Error::from(IntegrityPoolError::PublisherNeedsToSign),
-        0,
+        IntegrityPoolError::PublisherNeedsToSign,
+        0
     );
 
     // now the actual publisher signs
@@ -97,7 +92,7 @@ fn test_set_publisher_stake_account() {
     );
 
     // now only the stake account owner can change this, the publisher fails to change it
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         set_publisher_stake_account(
             &mut svm,
             &payer,
@@ -106,12 +101,12 @@ fn test_set_publisher_stake_account() {
             Some(stake_account_positions),
             stake_account_positions_2,
         ),
-        Error::from(IntegrityPoolError::StakeAccountOwnerNeedsToSign),
-        0,
+        IntegrityPoolError::StakeAccountOwnerNeedsToSign,
+        0
     );
 
     // missing the current stake account, fail
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         set_publisher_stake_account(
             &mut svm,
             &payer,
@@ -120,12 +115,12 @@ fn test_set_publisher_stake_account() {
             None,
             stake_account_positions_2,
         ),
-        Error::from(ErrorCode::AccountNotEnoughKeys),
-        0,
+        ErrorCode::AccountNotEnoughKeys,
+        0
     );
 
     // current stake account is wrong
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         set_publisher_stake_account(
             &mut svm,
             &payer,
@@ -134,8 +129,8 @@ fn test_set_publisher_stake_account() {
             Some(stake_account_positions_2),
             stake_account_positions_2,
         ),
-        Error::from(IntegrityPoolError::PublisherStakeAccountMismatch),
-        0,
+        IntegrityPoolError::PublisherStakeAccountMismatch,
+        0
     );
 
     // new stake account is delegated
@@ -149,7 +144,7 @@ fn test_set_publisher_stake_account() {
     )
     .unwrap();
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         set_publisher_stake_account(
             &mut svm,
             &payer,
@@ -158,8 +153,8 @@ fn test_set_publisher_stake_account() {
             Some(stake_account_positions),
             stake_account_positions_3,
         ),
-        Error::from(IntegrityPoolError::NewStakeAccountShouldBeUndelegated),
-        0,
+        IntegrityPoolError::NewStakeAccountShouldBeUndelegated,
+        0
     );
 
 
@@ -192,7 +187,7 @@ fn test_set_publisher_stake_account() {
     )
     .unwrap();
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         set_publisher_stake_account(
             &mut svm,
             &payer,
@@ -201,12 +196,12 @@ fn test_set_publisher_stake_account() {
             Some(stake_account_positions_2),
             stake_account_positions_3,
         ),
-        Error::from(IntegrityPoolError::CurrentStakeAccountShouldBeUndelegated),
-        0,
+        IntegrityPoolError::CurrentStakeAccountShouldBeUndelegated,
+        0
     );
 
     // lastly, if the publisher doesn't exist, fail
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         set_publisher_stake_account(
             &mut svm,
             &payer,
@@ -215,8 +210,8 @@ fn test_set_publisher_stake_account() {
             Some(stake_account_positions),
             stake_account_positions_2,
         ),
-        Error::from(IntegrityPoolError::PublisherNotFound),
-        0,
+        IntegrityPoolError::PublisherNotFound,
+        0
     );
 
     // test the interactions between set_publisher_stake_account and delegate/undelegate

--- a/staking/integration-tests/tests/staking_slash.rs
+++ b/staking/integration-tests/tests/staking_slash.rs
@@ -2,6 +2,7 @@ use {
     anchor_lang::AccountDeserialize,
     anchor_spl::token::TokenAccount,
     integration_tests::{
+        assert_anchor_program_error,
         setup::{
             setup,
             SetupProps,
@@ -26,10 +27,7 @@ use {
                 get_target_address,
             },
         },
-        utils::{
-            clock::advance_n_epochs,
-            error::assert_anchor_program_error,
-        },
+        utils::clock::advance_n_epochs,
     },
     integrity_pool::utils::types::FRAC_64_MULTIPLIER,
     solana_sdk::{
@@ -109,7 +107,7 @@ fn test_staking_slash() {
     // at epoch N+2, we can slash epoch N+1
     advance_n_epochs(&mut svm, &payer, 2);
 
-    assert_anchor_program_error(
+    assert_anchor_program_error!(
         slash_staking(
             &mut svm,
             &payer,
@@ -119,8 +117,8 @@ fn test_staking_slash() {
             publisher_keypair.pubkey(),
             slash_token_account.pubkey(),
         ),
-        ErrorCode::InvalidSlashRatio.into(),
-        0,
+        ErrorCode::InvalidSlashRatio,
+        0
     );
 
     slash_staking(


### PR DESCRIPTION
This PR refactors the `assert_anchor_program_error` to `assert_anchor_program_error!` macro for the following reasons.

1. When the assert fails it now shows exactly which one failed, instead of referring to the inside of the fuction.
2. It's more aligned with other asserts that are all macros.