### PR TITLE
fix: forbid zero pubkey

### DIFF
--- a/staking/integration-tests/src/publisher_caps/utils.rs
+++ b/staking/integration-tests/src/publisher_caps/utils.rs
@@ -104,7 +104,8 @@ pub fn create_dummy_publisher_caps_message(
     });
 
 
-    for i in 1..MAX_CAPS {
+    // we leave the last publisher slot empty
+    for i in 1..MAX_CAPS - 1 {
         caps.push(PublisherStakeCap {
             publisher: get_dummy_publisher(i).to_bytes(),
             cap:       i as u64,

--- a/staking/integration-tests/tests/advance.rs
+++ b/staking/integration-tests/tests/advance.rs
@@ -76,10 +76,12 @@ fn test_advance() {
 
     let pool_data = fetch_account_data_bytemuck::<PoolData>(&mut svm, &pool_data_pubkey);
 
-    let mut publisher_pubkeys = (1..MAX_PUBLISHERS)
+    let mut publisher_pubkeys = (1..MAX_PUBLISHERS - 1)
         .map(get_dummy_publisher)
         .collect::<Vec<Pubkey>>();
     publisher_pubkeys.sort();
+    publisher_pubkeys.push(Pubkey::default());
+
 
     for i in 0..MAX_PUBLISHERS {
         match i {

--- a/staking/integration-tests/tests/delegate.rs
+++ b/staking/integration-tests/tests/delegate.rs
@@ -68,6 +68,20 @@ fn test_delegate() {
     let stake_account_positions =
         initialize_new_stake_account(&mut svm, &payer, &pyth_token_mint, true, true);
 
+    assert_anchor_program_error!(
+        delegate(
+            &mut svm,
+            &payer,
+            Pubkey::default(), // can't delegate to zero pubkey
+            pool_data_pubkey,
+            stake_account_positions,
+            100,
+        ),
+        IntegrityPoolError::InvalidPublisher,
+        0
+    );
+
+
     delegate(
         &mut svm,
         &payer,

--- a/staking/programs/integrity-pool/src/error.rs
+++ b/staking/programs/integrity-pool/src/error.rs
@@ -29,4 +29,5 @@ pub enum IntegrityPoolError {
     PublisherCustodyAccountRequired,
     #[msg("Delegation fee must not be greater than 100%")]
     InvalidDelegationFee,
+    InvalidPublisher,
 }

--- a/staking/programs/integrity-pool/src/state/pool.rs
+++ b/staking/programs/integrity-pool/src/state/pool.rs
@@ -315,6 +315,10 @@ impl PoolData {
     }
 
     pub fn get_publisher_index(&self, publisher: &Pubkey) -> Result<usize> {
+        if *publisher == Pubkey::default() {
+            return err!(IntegrityPoolError::InvalidPublisher);
+        }
+
         for i in 0..MAX_PUBLISHERS {
             if self.publishers[i] == *publisher {
                 return Ok(i);


### PR DESCRIPTION
This is a bug. People could stake to 0 pubkey, writing data to free publisher slots.