### PR TITLE
fix: typo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,7 @@
     "Metas",
     "PREUNLOCKING",
     "Pubkey",
+    "pubkeys",
     "pyth",
     "pythnet",
     "quickcheck",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,31 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer"
   },
   "rust-analyzer.check.command": "clippy",
-  "rust-analyzer.rustfmt.overrideCommand": ["rustfmt", "+nightly"]
+  "rust-analyzer.rustfmt.overrideCommand": ["rustfmt", "+nightly"],
+  "cSpell.words": [
+    "accs",
+    "blockhash",
+    "borsh",
+    "bytemuck",
+    "delegators",
+    "Keypair",
+    "keypairs",
+    "lamports",
+    "litesvm",
+    "Merkle",
+    "Metas",
+    "PREUNLOCKING",
+    "Pubkey",
+    "pyth",
+    "pythnet",
+    "quickcheck",
+    "snapshotted",
+    "solana",
+    "sysvar",
+    "Undelegate",
+    "undelegated",
+    "UNDELEGATION",
+    "vaas",
+    "Zeroable"
+  ]
 }

--- a/staking/integration-tests/src/integrity_pool/instructions.rs
+++ b/staking/integration-tests/src/integrity_pool/instructions.rs
@@ -10,7 +10,7 @@ use {
         staking::pda::{
             get_config_address,
             get_stake_account_custody_address,
-            get_stake_account_custory_authority_address,
+            get_stake_account_custody_authority_address,
             get_stake_account_metadata_address,
             get_target_address,
         },
@@ -478,7 +478,7 @@ pub fn slash(
     let delegation_record = get_delegation_record_address(publisher, stake_account_positions);
     let stake_account_metadata = get_stake_account_metadata_address(stake_account_positions);
     let stake_account_custody = get_stake_account_custody_address(stake_account_positions);
-    let custody_authority = get_stake_account_custory_authority_address(stake_account_positions);
+    let custody_authority = get_stake_account_custody_authority_address(stake_account_positions);
     let config = get_config_address();
     let target_account = get_target_address();
 

--- a/staking/integration-tests/src/staking/instructions.rs
+++ b/staking/integration-tests/src/staking/instructions.rs
@@ -4,7 +4,7 @@ use {
         get_config_address_bump,
         get_max_voter_record_address,
         get_stake_account_custody_address,
-        get_stake_account_custory_authority_address,
+        get_stake_account_custody_authority_address,
         get_stake_account_metadata_address,
         get_target_address,
         get_voter_record_address,
@@ -263,7 +263,7 @@ pub fn create_stake_account(
 ) -> TransactionResult {
     let stake_account_metadata = get_stake_account_metadata_address(stake_account_positions);
     let stake_account_custody = get_stake_account_custody_address(stake_account_positions);
-    let custody_authority = get_stake_account_custory_authority_address(stake_account_positions);
+    let custody_authority = get_stake_account_custody_authority_address(stake_account_positions);
     let config_account = get_config_address();
 
     let create_stake_account_data = staking::instruction::CreateStakeAccount {
@@ -347,7 +347,7 @@ pub fn slash_staking(
     let stake_account_metadata = get_stake_account_metadata_address(stake_account_positions);
     let stake_account_custody = get_stake_account_custody_address(stake_account_positions);
     let stake_account_authority =
-        get_stake_account_custory_authority_address(stake_account_positions);
+        get_stake_account_custody_authority_address(stake_account_positions);
 
     let slash_account_accs = staking::accounts::SlashAccount {
         config: config_pubkey,

--- a/staking/integration-tests/src/staking/pda.rs
+++ b/staking/integration-tests/src/staking/pda.rs
@@ -45,7 +45,7 @@ pub fn get_stake_account_custody_address(stake_account_positions: Pubkey) -> Pub
     .0
 }
 
-pub fn get_stake_account_custory_authority_address(stake_account_positions: Pubkey) -> Pubkey {
+pub fn get_stake_account_custody_authority_address(stake_account_positions: Pubkey) -> Pubkey {
     Pubkey::find_program_address(
         &[
             staking::context::AUTHORITY_SEED.as_bytes(),

--- a/staking/programs/integrity-pool/src/context.rs
+++ b/staking/programs/integrity-pool/src/context.rs
@@ -180,7 +180,7 @@ pub struct Undelegate<'info> {
     #[account(seeds = [POOL_CONFIG.as_bytes()], bump, has_one = pool_data)]
     pub pool_config: Account<'info, PoolConfig>,
 
-    /// CHECK : The publisher will be checked againts data in the pool_data
+    /// CHECK : The publisher will be checked against data in the pool_data
     pub publisher: AccountInfo<'info>,
 
     #[account(


### PR DESCRIPTION
This PR fixes all the typos in the repo and add a list of known words to vs code settings so that we can use the spell checker efficiently to avoid having typos in the future.