### PR TITLE
[chore] bump wasm version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3885,9 +3885,9 @@
       }
     },
     "node_modules/@pythnetwork/staking-wasm": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/staking-wasm/-/staking-wasm-0.3.4.tgz",
-      "integrity": "sha512-0ZdaWmueVO5hucdVH4UDfHyBuxtW6UDcrpEFtD/3pq4naQjcgu1u6rK8iL2pgKi8W2UlsB4vwJqay2Sf1sA4mw=="
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/staking-wasm/-/staking-wasm-0.3.5.tgz",
+      "integrity": "sha512-iQpPPn6kPuc9Q1MO+PMAKAhkuv6AOUHiAZJizCbPm3aO7kS2YxRKsRSMsky9FY1GHHatSx13LX9epsJXi/MmKg=="
     },
     "node_modules/@pythnetwork/staking/node_modules/typescript": {
       "version": "4.9.5",


### PR DESCRIPTION
When we merged the new changes to the staking program and we started using the npm version of `@pythnetwork/staking-wasm` and `@pythnetwork/staking` in the frontend, the npm version of `@pythnetwork/staking-wasm` actually outdated.

I'm fixing this by making a new release of `@pythnetwork/staking-wasm` from https://github.com/pyth-network/governance/tree/pyth-staking-v2.3.0 and using it in main.