### PR TITLE
feat: refactor reward logic in advance

### DIFF
--- a/staking/programs/integrity-pool/src/state/pool.rs
+++ b/staking/programs/integrity-pool/src/state/pool.rs
@@ -330,33 +330,6 @@ impl PoolData {
         Ok(())
     }
 
-    pub fn get_publisher_reward_ratios(
-        &self,
-        publisher_index: usize,
-        publisher_cap: u64,
-    ) -> Result<(u64, u64)> {
-        let self_delegation = self.self_del_state[publisher_index].total_delegation;
-        let self_eligible_delegation = min(publisher_cap, self_delegation);
-        // the order of the operation matters to avoid floating point precision issues
-        let self_reward_ratio: frac64 = (FRAC_64_MULTIPLIER_U128
-            * u128::from(self_eligible_delegation))
-        .checked_div(u128::from(self_delegation))
-        .unwrap_or(0)
-        .try_into()?;
-
-        let other_delegation = self.del_state[publisher_index].total_delegation;
-        let other_eligible_delegation =
-            min(publisher_cap - self_eligible_delegation, other_delegation);
-        // the order of the operation matters to avoid floating point precision issues
-        let other_reward_ratio: frac64 = (FRAC_64_MULTIPLIER_U128
-            * u128::from(other_eligible_delegation))
-        .checked_div(u128::from(other_delegation))
-        .unwrap_or(0)
-        .try_into()?;
-
-        Ok((self_reward_ratio, other_reward_ratio))
-    }
-
     pub fn create_reward_events_for_publisher(
         &mut self,
         epoch_from: u64,
@@ -372,7 +345,6 @@ impl PoolData {
                 delegation_fee:     self.delegation_fees[publisher_index],
             };
         }
-
         Ok(())
     }
 

--- a/staking/programs/integrity-pool/src/state/pool.rs
+++ b/staking/programs/integrity-pool/src/state/pool.rs
@@ -221,6 +221,7 @@ impl PoolData {
         Ok((delegator_reward, publisher_reward))
     }
 
+
     pub fn advance(
         &mut self,
         publisher_caps: &PublisherCaps,
@@ -281,8 +282,8 @@ impl PoolData {
             self.create_reward_events_for_publisher(
                 self.last_updated_epoch,
                 self.last_updated_epoch + 1,
-                eligible_delegation_data.get_reward_ratios()?,
                 i,
+                eligible_delegation_data.get_reward_ratios()?,
             )?;
 
             self.del_state[i] = DelegationState {
@@ -310,8 +311,8 @@ impl PoolData {
             self.create_reward_events_for_publisher(
                 self.last_updated_epoch + 1,
                 current_epoch,
-                eligible_delegation_data.get_reward_ratios()?,
                 i,
+                eligible_delegation_data.get_reward_ratios()?,
             )?;
             i += 1;
         }
@@ -334,8 +335,8 @@ impl PoolData {
         &mut self,
         epoch_from: u64,
         epoch_to: u64,
-        reward_ratios: RewardRatios,
         publisher_index: usize,
+        reward_ratios: RewardRatios,
     ) -> Result<()> {
         for epoch in epoch_from..epoch_to {
             self.get_event_mut((self.num_events + epoch - self.last_updated_epoch).try_into()?)

--- a/staking/programs/integrity-pool/src/state/pool.rs
+++ b/staking/programs/integrity-pool/src/state/pool.rs
@@ -456,7 +456,6 @@ pub struct PoolConfig {
     pub reward_program_authority: Pubkey,
     pub pyth_token_mint:          Pubkey,
     pub y:                        frac64,
-    pub unclaimed_rewards:        u64, // an upper bound on the number of unclaimed rewards
 }
 
 impl PoolConfig {
@@ -478,9 +477,6 @@ mod tests {
         },
         staking::state::positions::DynamicPositionArrayAccount,
     };
-
-    pub const YIELD: frac64 = FRAC_64_MULTIPLIER / 100;
-
 
     #[test]
     #[allow(deprecated)]

--- a/staking/programs/integrity-pool/src/state/pool.rs
+++ b/staking/programs/integrity-pool/src/state/pool.rs
@@ -14,7 +14,6 @@ use {
             types::{
                 frac64,
                 BoolArray,
-                FRAC_64_MULTIPLIER,
                 FRAC_64_MULTIPLIER_U128,
             },
         },

--- a/staking/programs/integrity-pool/src/state/pool.rs
+++ b/staking/programs/integrity-pool/src/state/pool.rs
@@ -257,7 +257,6 @@ impl PoolData {
         let epochs_passed = current_epoch - self.last_updated_epoch;
         let mut i = 0;
 
-        let mut total_eligible_delegation = 0;
         while i < MAX_PUBLISHERS && self.publishers[i] != Pubkey::default() {
             let cap_index = publisher_caps
                 .caps()

--- a/staking/programs/integrity-pool/src/state/pool.rs
+++ b/staking/programs/integrity-pool/src/state/pool.rs
@@ -531,6 +531,7 @@ mod tests {
         pool_data.publisher_stake_accounts[publisher_index] = publisher_key;
         pool_data.publishers[publisher_index] = publisher_key;
 
+
         let mut event = Event {
             epoch:       1,
             y:           FRAC_64_MULTIPLIER / 10, // 10%
@@ -632,6 +633,7 @@ mod tests {
 
         assert_eq!(delegator_reward, 94 * FRAC_64_MULTIPLIER);
 
+
         // test many events
         pool_data.num_events = 100;
         pool_data.last_updated_epoch = 101;
@@ -681,8 +683,18 @@ mod tests {
 
         for (index, cap) in caps.iter().enumerate() {
             pool_data.publishers[index] = cap.pubkey;
+            let eligible_delegation_data = EligibleDelegationData::from_delegation_data(
+                pool_data.self_del_state[index].total_delegation,
+                pool_data.del_state[index].total_delegation,
+                cap.cap,
+            );
             pool_data
-                .create_reward_events_for_publisher(1, 2, index, cap.cap, YIELD)
+                .create_reward_events_for_publisher(
+                    1,
+                    2,
+                    index,
+                    eligible_delegation_data.get_reward_ratios().unwrap(),
+                )
                 .unwrap();
         }
 
@@ -724,8 +736,18 @@ mod tests {
 
         for (index, cap) in caps.iter().enumerate() {
             pool_data.publishers[index] = cap.pubkey;
+            let eligible_delegation_data = EligibleDelegationData::from_delegation_data(
+                pool_data.self_del_state[index].total_delegation,
+                pool_data.del_state[index].total_delegation,
+                cap.cap,
+            );
             pool_data
-                .create_reward_events_for_publisher(1, 2, index, cap.cap, FRAC_64_MULTIPLIER / 100)
+                .create_reward_events_for_publisher(
+                    1,
+                    2,
+                    index,
+                    eligible_delegation_data.get_reward_ratios().unwrap(),
+                )
                 .unwrap();
         }
 


### PR DESCRIPTION
This refactor will allow me to access `total_eligible_delegation` in the main loop. I will use that to compute claimed_rewards. 