### PR TITLE
fix: don't load all accounts at the same time in request

### DIFF
--- a/frontend/pages/approve.tsx
+++ b/frontend/pages/approve.tsx
@@ -62,12 +62,13 @@ const ApproveSplit: NextPage = () => {
   const handleSelectStakeAccount = (event: any) => {
     const loadStakeAccount = async () => {
     if (stakeAccounts && stakeConnection){
-      for (const stakeAccount of stakeAccounts) {
-        if (stakeAccount.toString() === event.target.value) {
+        const stakeAccount = stakeAccounts.find(s => s.toString() === event.target.value)
+        if (stakeAccount) {
           setSelectStakeAccount(await stakeConnection.loadStakeAccount(stakeAccount))
-          break
         }
-      }
+        else {
+          setSelectStakeAccount(undefined)
+        }
     }
     }
     loadStakeAccount()
@@ -78,7 +79,11 @@ const ApproveSplit: NextPage = () => {
       if (stakeConnection && anchorWallet && owner) {
         const stakeAccounts = await getStakeAccountsPubkeys(new PublicKey(owner), stakeConnection)
         setStakeAccounts(stakeAccounts)
-        setSelectStakeAccount(await stakeConnection.loadStakeAccount(stakeAccounts[0]))
+        if (stakeAccounts.length > 0){
+          setSelectStakeAccount(await stakeConnection.loadStakeAccount(stakeAccounts[0]))
+        } else {
+          setSelectStakeAccount(undefined)
+        }
       } else {
         setStakeAccounts(undefined)
       }

--- a/frontend/pages/approve.tsx
+++ b/frontend/pages/approve.tsx
@@ -11,7 +11,7 @@ import { capitalizeFirstLetter } from 'utils/capitalizeFirstLetter'
 import { useStakeConnection } from 'hooks/useStakeConnection'
 import { useSplitRequest } from 'hooks/useSplitRequest'
 
-async function getStakeAccountsPubkeys(user: PublicKey, stakeConnection : StakeConnection){
+export async function getStakeAccountsPubkeys(user: PublicKey, stakeConnection : StakeConnection){
   const program = stakeConnection.program;
   const res = await stakeConnection.program.provider.connection.getProgramAccounts(
     program.programId,

--- a/frontend/pages/approve.tsx
+++ b/frontend/pages/approve.tsx
@@ -66,9 +66,6 @@ const ApproveSplit: NextPage = () => {
         if (stakeAccount) {
           setSelectStakeAccount(await stakeConnection.loadStakeAccount(stakeAccount))
         }
-        else {
-          setSelectStakeAccount(undefined)
-        }
     }
     }
     loadStakeAccount()

--- a/frontend/pages/request.tsx
+++ b/frontend/pages/request.tsx
@@ -51,7 +51,11 @@ const RequestSplit: NextPage = () => {
       if (stakeConnection) {
         const stakeAccounts = await getStakeAccountsPubkeys(stakeConnection.userPublicKey(), stakeConnection)
         setStakeAccounts(stakeAccounts)
-        setSelectStakeAccount(await stakeConnection.loadStakeAccount(stakeAccounts[0]))
+        if (stakeAccounts.length > 0){
+          setSelectStakeAccount(await stakeConnection.loadStakeAccount(stakeAccounts[0]))
+        } else {
+          setSelectStakeAccount(undefined)
+        }
       } else {
         setStakeAccounts(undefined)
       }
@@ -62,11 +66,12 @@ const RequestSplit: NextPage = () => {
   const handleSelectStakeAccount = (event: any) => {
     const loadStakeAccount = async () => {
     if (stakeAccounts && stakeConnection){
-      for (const stakeAccount of stakeAccounts) {
-        if (stakeAccount.toString() === event.target.value) {
-          setSelectStakeAccount(await stakeConnection.loadStakeAccount(stakeAccount))
-          break
-        }
+      const stakeAccount = stakeAccounts.find(s => s.toString() === event.target.value)
+      if (stakeAccount) {
+        setSelectStakeAccount(await stakeConnection.loadStakeAccount(stakeAccount))
+      }
+      else {
+        setSelectStakeAccount(undefined)
       }
     }
     }

--- a/frontend/pages/request.tsx
+++ b/frontend/pages/request.tsx
@@ -7,8 +7,8 @@ import { PublicKey } from '@solana/web3.js'
 import toast from 'react-hot-toast'
 import { capitalizeFirstLetter } from 'utils/capitalizeFirstLetter'
 import { useStakeConnection } from 'hooks/useStakeConnection'
-import { useStakeAccounts } from 'hooks/useStakeAccounts'
 import { useSplitRequest } from 'hooks/useSplitRequest'
+import { getStakeAccountsPubkeys } from './approve'
 
 const RequestSplit: NextPage = () => {
   const [recipient, setRecipient] = useState<PublicKey>()
@@ -30,7 +30,7 @@ const RequestSplit: NextPage = () => {
   }
 
   const { data: stakeConnection } = useStakeConnection()
-  const { data: stakeAccounts } = useStakeAccounts()
+  const [stakeAccounts, setStakeAccounts] = useState<PublicKey[]>()
   const [selectedStakeAccount, setSelectStakeAccount] = useState<StakeAccount>()
   const { data: initialSplitRequest } = useSplitRequest(selectedStakeAccount)
 
@@ -46,13 +46,31 @@ const RequestSplit: NextPage = () => {
     loadWalletHasTested()
   }, [recipient])
 
-  const handleSelectStakeAccount = (event: any) => {
-    for (const stakeAccount of stakeAccounts!) {
-      if (stakeAccount.address.toString() === event.target.value) {
-        setSelectStakeAccount(stakeAccount)
-        break
+  useEffect(() => {
+    const loadStakeAccounts = async () => {
+      if (stakeConnection) {
+        const stakeAccounts = await getStakeAccountsPubkeys(stakeConnection.userPublicKey(), stakeConnection)
+        setStakeAccounts(stakeAccounts)
+        setSelectStakeAccount(await stakeConnection.loadStakeAccount(stakeAccounts[0]))
+      } else {
+        setStakeAccounts(undefined)
       }
     }
+    loadStakeAccounts()
+  }, [stakeConnection])
+
+  const handleSelectStakeAccount = (event: any) => {
+    const loadStakeAccount = async () => {
+    if (stakeAccounts && stakeConnection){
+      for (const stakeAccount of stakeAccounts) {
+        if (stakeAccount.toString() === event.target.value) {
+          setSelectStakeAccount(await stakeConnection.loadStakeAccount(stakeAccount))
+          break
+        }
+      }
+    }
+    }
+    loadStakeAccount()
   }
 
   useEffect(() => {
@@ -64,11 +82,6 @@ const RequestSplit: NextPage = () => {
       setBalance(undefined)
     }
   }, [initialSplitRequest])
-
-  useEffect(() => {
-    if (stakeAccounts && stakeAccounts.length > 0)
-      setSelectStakeAccount(stakeAccounts[0])
-  }, [stakeAccounts])
 
   const requestSplit = async () => {
     if (stakeConnection && selectedStakeAccount && recipient && balance)
@@ -102,8 +115,8 @@ const RequestSplit: NextPage = () => {
               onChange={handleSelectStakeAccount}
             >
               {stakeAccounts!.map((option, index) => (
-                <option key={index} value={option.address.toBase58()}>
-                  {option.address.toString()}
+                <option key={index} value={option.toBase58()}>
+                  {option.toString()}
                 </option>
               ))}
             </select>

--- a/frontend/pages/request.tsx
+++ b/frontend/pages/request.tsx
@@ -70,9 +70,6 @@ const RequestSplit: NextPage = () => {
       if (stakeAccount) {
         setSelectStakeAccount(await stakeConnection.loadStakeAccount(stakeAccount))
       }
-      else {
-        setSelectStakeAccount(undefined)
-      }
     }
     }
     loadStakeAccount()


### PR DESCRIPTION
Like https://github.com/pyth-network/governance/pull/504 for requesting. We avoid loading all stake accounts at the same time.