### PR TITLE
**Fix Typo in `positions.rs`**

### DIFF
--- a/staking/programs/staking/src/state/positions.rs
+++ b/staking/programs/staking/src/state/positions.rs
@@ -566,7 +566,7 @@ impl Position {
 
     /**
      * Two positions are equivalent if they have the same state for the current and previous
-     * epoch. This is because we never check the state of a position for epochs futher in
+     * epoch. This is because we never check the state of a position for epochs further in
      * the past than 1 epoch. An exception to this rule is claimimng rewards in integrity
      * pool, therefore `pool_authority` should ensure rewards have been claimed before
      * allowing merging positions.


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `positions.rs`**

## Description  
This pull request addresses a minor typo in the `positions.rs` file, improving the accuracy and readability of the code comments.

### Changes Made:
- **File Modified:** `staking/programs/staking/src/state/positions.rs`
- **Summary of Changes:**
  - Corrected "futher" to "further" in the comment describing epoch state checks.

## Checklist  
- [x] Fixed the typo in the comment.
- [x] Verified that the changes do not affect functional code or logic.

## Additional Notes  
This change helps maintain precise documentation for developers reviewing the epoch state logic and position state equivalence criteria.

---

**Allow edits by maintainers:** [x]
