### PR TITLE
feat: add withdraw instruction for reward_program_authority

### DIFF
--- a/staking/integration-tests/src/integrity_pool/instructions.rs
+++ b/staking/integration-tests/src/integrity_pool/instructions.rs
@@ -94,6 +94,43 @@ pub fn advance(svm: &mut LiteSVM, payer: &Keypair, publisher_caps: Pubkey) -> Tr
     svm.send_transaction(transaction)
 }
 
+pub fn withdraw(
+    svm: &mut LiteSVM,
+    payer: &Keypair,
+    reward_program_authority: &Keypair,
+    pyth_token_mint: Pubkey,
+    destination: Pubkey,
+    amount: u64,
+) -> TransactionResult {
+    let pool_config = get_pool_config_address();
+    let pool_reward_custody = get_pool_reward_custody_address(pyth_token_mint);
+
+    let accounts = integrity_pool::accounts::Withdraw {
+        reward_program_authority: reward_program_authority.pubkey(),
+        pool_config,
+        pool_reward_custody,
+        destination,
+        token_program: spl_token::ID,
+    };
+
+    let instruction_data = integrity_pool::instruction::Withdraw { amount };
+
+    let instruction = Instruction {
+        program_id: integrity_pool::ID,
+        accounts:   accounts.to_account_metas(None),
+        data:       instruction_data.data(),
+    };
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&payer.pubkey()),
+        &[payer, reward_program_authority],
+        svm.latest_blockhash(),
+    );
+
+    svm.send_transaction(transaction)
+}
+
 pub fn create_pool_data_account(
     svm: &mut litesvm::LiteSVM,
     payer: &Keypair,

--- a/staking/integration-tests/tests/withdraw.rs
+++ b/staking/integration-tests/tests/withdraw.rs
@@ -1,0 +1,104 @@
+use {
+    anchor_spl::token::TokenAccount,
+    integration_tests::{
+        assert_anchor_program_error,
+        integrity_pool::{
+            instructions::withdraw,
+            pda::get_pool_reward_custody_address,
+        },
+        setup::{
+            setup,
+            SetupProps,
+            SetupResult,
+        },
+        solana::{
+            instructions::create_token_account,
+            utils::fetch_account_data,
+        },
+    },
+    integrity_pool::{
+        error::IntegrityPoolError,
+        utils::types::FRAC_64_MULTIPLIER,
+    },
+    solana_sdk::{
+        signature::Keypair,
+        signer::Signer,
+    },
+};
+
+#[test]
+fn test_withdraw() {
+    let SetupResult {
+        mut svm,
+        payer,
+        pyth_token_mint,
+        publisher_keypair: _,
+        pool_data_pubkey: _,
+        reward_program_authority,
+        maybe_publisher_index: _,
+    } = setup(SetupProps {
+        init_config:            true,
+        init_target:            true,
+        init_mint:              true,
+        init_pool_data:         true,
+        init_publishers:        true,
+        reward_amount_override: None,
+    });
+
+    let pool_reward_custody = get_pool_reward_custody_address(pyth_token_mint.pubkey());
+    let initial_custody_amount =
+        fetch_account_data::<TokenAccount>(&mut svm, &pool_reward_custody).amount;
+
+    // an arbitrary destination token account of the same mint
+    let destination = create_token_account(&mut svm, &payer, &pyth_token_mint.pubkey()).pubkey();
+
+    let withdraw_amount = 123 * FRAC_64_MULTIPLIER;
+
+    // a random signer that is not the reward_program_authority cannot withdraw
+    assert_anchor_program_error!(
+        withdraw(
+            &mut svm,
+            &payer,
+            &Keypair::new(),
+            pyth_token_mint.pubkey(),
+            destination,
+            withdraw_amount,
+        ),
+        IntegrityPoolError::InvalidRewardProgramAuthority,
+        0
+    );
+
+    // the reward_program_authority can withdraw an arbitrary amount
+    withdraw(
+        &mut svm,
+        &payer,
+        &reward_program_authority,
+        pyth_token_mint.pubkey(),
+        destination,
+        withdraw_amount,
+    )
+    .unwrap();
+
+    // funds moved from the custody to the destination
+    let custody_amount = fetch_account_data::<TokenAccount>(&mut svm, &pool_reward_custody).amount;
+    let destination_amount = fetch_account_data::<TokenAccount>(&mut svm, &destination).amount;
+
+    assert_eq!(custody_amount, initial_custody_amount - withdraw_amount);
+    assert_eq!(destination_amount, withdraw_amount);
+
+    // cannot withdraw more than the custody holds (SPL token InsufficientFunds)
+    assert_anchor_program_error!(
+        withdraw(
+            &mut svm,
+            &payer,
+            &reward_program_authority,
+            pyth_token_mint.pubkey(),
+            destination,
+            custody_amount + 1,
+        ),
+        anchor_lang::prelude::ProgramError::from(
+            anchor_spl::token::spl_token::error::TokenError::InsufficientFunds
+        ),
+        0
+    );
+}

--- a/staking/programs/integrity-pool/src/context.rs
+++ b/staking/programs/integrity-pool/src/context.rs
@@ -343,6 +343,33 @@ pub struct AdvanceDelegationRecord<'info> {
 }
 
 #[derive(Accounts)]
+pub struct Withdraw<'info> {
+    pub reward_program_authority: Signer<'info>,
+
+    #[account(
+        seeds = [POOL_CONFIG.as_bytes()],
+        bump,
+        has_one = reward_program_authority @ IntegrityPoolError::InvalidRewardProgramAuthority,
+    )]
+    pub pool_config: Account<'info, PoolConfig>,
+
+    #[account(
+        mut,
+        associated_token::mint = pool_config.pyth_token_mint,
+        associated_token::authority = pool_config.key(),
+    )]
+    pub pool_reward_custody: Account<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        token::mint = pool_config.pyth_token_mint,
+    )]
+    pub destination: Account<'info, TokenAccount>,
+
+    pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
 #[instruction(index: u64, slash_ratio: u64)]
 pub struct CreateSlashEvent<'info> {
     #[account(mut)]

--- a/staking/programs/integrity-pool/src/lib.rs
+++ b/staking/programs/integrity-pool/src/lib.rs
@@ -377,6 +377,28 @@ pub mod integrity_pool {
         Ok(delegator_reward)
     }
 
+    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {
+        let pool_config = &ctx.accounts.pool_config;
+        let pool_reward_custody = &ctx.accounts.pool_reward_custody;
+        let destination = &ctx.accounts.destination;
+        let token_program = &ctx.accounts.token_program;
+
+        // transfer tokens from pool_reward_custody to destination, signed by the
+        // pool_config PDA (whose authority is gated by reward_program_authority above)
+        let cpi_accounts = anchor_spl::token::Transfer {
+            from:      pool_reward_custody.to_account_info(),
+            to:        destination.to_account_info(),
+            authority: pool_config.to_account_info(),
+        };
+        let signer_seeds: &[&[&[u8]]] = &[&[POOL_CONFIG.as_bytes(), &[ctx.bumps.pool_config]]];
+
+        let transfer_ctx = CpiContext::new(token_program.to_account_info(), cpi_accounts)
+            .with_signer(signer_seeds);
+        anchor_spl::token::transfer(transfer_ctx, amount)?;
+
+        Ok(())
+    }
+
     pub fn create_slash_event(
         ctx: Context<CreateSlashEvent>,
         index: u64,


### PR DESCRIPTION
Add a `withdraw` instruction to the integrity-pool program that lets the reward_program_authority transfer an arbitrary amount of tokens out of pool_reward_custody to a destination token account, signed by the pool_config PDA. Includes an integration test covering the happy path, the authority gate, and insufficient-funds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/governance/pull/575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->